### PR TITLE
fix: Identical hash commits should skip comparison

### DIFF
--- a/packages/best-cli/src/cli/index.js
+++ b/packages/best-cli/src/cli/index.js
@@ -70,7 +70,9 @@ export async function runCLI(argsCLI, projects) {
 
     if (globalConfig.compareStats) {
         results = await runCompare(globalConfig, configs, outputStream);
-        generateComparisonTable(results, outputStream);
+        if (results) {
+            generateComparisonTable(results, outputStream);
+        }
 
     } else {
         if (argsCLI.clearResults) {

--- a/packages/best-cli/src/run_compare.js
+++ b/packages/best-cli/src/run_compare.js
@@ -1,9 +1,11 @@
 import { preRunMessager } from "@best/messager";
 import { compareBenchmarkStats } from "@best/compare";
 import { pushBenchmarkComparison } from "@best/github-integration";
+import { basename } from "path";
 
 export async function runCompare(globalConfig, configs, outputStream) {
     const { gitIntegration, externalStorage, compareStats: commits } = globalConfig;
+    const [baseCommit, compareCommit] = commits;
 
     if (configs.length > 1) {
         throw new Error('WIP - Do not support multiple projects for compare just yet...');
@@ -17,8 +19,12 @@ export async function runCompare(globalConfig, configs, outputStream) {
         throw new Error('Wrong number of commmits to compare we are expectine one or two');
     }
 
+    if (baseCommit === compareCommit) {
+        console.log(`Hash of commits are identical (${baseCommit}). Skipping comparison`);
+        return false;
+    }
+
     const projectConfig = configs[0];
-    const [baseCommit, compareCommit] = commits;
     const { projectName } = projectConfig;
     let storageProvider;
     try {

--- a/packages/best-config/src/index.js
+++ b/packages/best-config/src/index.js
@@ -95,7 +95,7 @@ function setFromArgs(initialOptions, argsCLI) {
             }
             return options;
         }, {});
-    console.log(argvToOptions);
+
     return Object.assign({}, initialOptions, argvToOptions);
 }
 


### PR DESCRIPTION
- Guard for identical hashes
- Remove console log  