### PR TITLE
test(best-build): Add tests for best build

### DIFF
--- a/packages/best-build/src/__tests__/best-build.spec.js
+++ b/packages/best-build/src/__tests__/best-build.spec.js
@@ -1,0 +1,129 @@
+import * as os from 'os';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { buildBenchmark } from '../index';
+
+const TEMP_DIR_PREFIX = 'best-test-';
+const MOCK_MESSAGER = {
+    onBenchmarkBuildStart() {},
+    onBenchmarkBuildEnd() {},
+};
+
+function tempDir() {
+    return fs.mkdtempSync(path.join(os.tmpdir(), TEMP_DIR_PREFIX));
+}
+
+describe('buildBenchmark', () => {
+    test('generating index.js and index.html', async () => {
+        const cacheDirectory = tempDir();
+        const res = await buildBenchmark(
+            path.resolve(__dirname, 'fixtures', 'single-file', 'single-file.js'),
+            {
+                cacheDirectory,
+            },
+            {},
+            MOCK_MESSAGER,
+        );
+
+        expect(fs.statSync(`${cacheDirectory}/single-file`).isDirectory()).toBe(true);
+        expect(fs.statSync(`${cacheDirectory}/single-file/single-file.html`).isFile()).toBe(true);
+        expect(fs.statSync(`${cacheDirectory}/single-file/single-file.js`).isFile()).toBe(true);
+    });
+
+    test('build output', async () => {
+        const { benchmarkName, benchmarkEntry, benchmarkFolder, benchmarkSignature } = await buildBenchmark(
+            path.resolve(__dirname, 'fixtures', 'single-file', 'single-file.js'),
+            {
+                cacheDirectory: tempDir(),
+            },
+            {},
+            MOCK_MESSAGER,
+        );
+
+        expect(benchmarkName).toBe('single-file');
+        expect(benchmarkFolder.endsWith('single-file')).toBe(true);
+        expect(benchmarkEntry.endsWith('single-file/single-file.html')).toBe(true);
+        expect(typeof benchmarkSignature).toBe('string');
+    });
+
+    test('calling messager before and after the build', async () => {
+        const messager = {
+            onBenchmarkBuildStart: jest.fn(),
+            onBenchmarkBuildEnd: jest.fn(),
+        };
+
+        await buildBenchmark(
+            path.resolve(__dirname, 'fixtures', 'single-file', 'single-file.js'),
+            {
+                cacheDirectory: tempDir(),
+            },
+            {},
+            messager,
+        );
+
+        expect(messager.onBenchmarkBuildStart).toHaveBeenCalled();
+        expect(messager.onBenchmarkBuildEnd).toHaveBeenCalled();
+    });
+
+    test('plugin receives options when required', async () => {
+        expect.hasAssertions();
+
+        const PLUGIN_OPTIONS = {
+            foo: 'bar'
+        };
+
+        jest.doMock('build-plugin-opts', () => {
+            return (options) => {
+                expect(options).toBe(PLUGIN_OPTIONS);
+                return {};
+            };
+        }, {
+            virtual: true
+        });
+
+        await buildBenchmark(
+            path.resolve(__dirname, 'fixtures', 'single-file', 'single-file.js'),
+            {
+                cacheDirectory: tempDir(),
+                plugins: {
+                    'build-plugin-opts': PLUGIN_OPTIONS
+                }
+            },
+            {},
+            MOCK_MESSAGER,
+        );
+    });
+
+    test('plugin hooks into rollup lifecycle hooks', async () => {
+        const entry = path.resolve(__dirname, 'fixtures', 'single-file', 'single-file.js');
+        const loaded = [];
+        const transformed = [];
+
+        jest.doMock('build-plugin-hooks', () => {
+            return (options) => {
+                return {
+                    load: (id) => { loaded.push(id) },
+                    transform: (src, id) => { transformed.push(id) },
+                };
+            };
+        }, {
+            virtual: true
+        });
+
+        await buildBenchmark(
+            path.resolve(__dirname, 'fixtures', 'single-file', 'single-file.js'),
+            {
+                cacheDirectory: tempDir(),
+                plugins: {
+                    'build-plugin-hooks': true
+                }
+            },
+            {},
+            MOCK_MESSAGER,
+        );
+
+        expect(loaded.some(file => file === entry)).toBe(true);
+        expect(transformed.some(file => file === entry)).toBe(true);
+    });
+});

--- a/packages/best-build/src/__tests__/fixtures/single-file/single-file.js
+++ b/packages/best-build/src/__tests__/fixtures/single-file/single-file.js
@@ -1,0 +1,1 @@
+console.log('hello')

--- a/packages/best-build/src/index.js
+++ b/packages/best-build/src/index.js
@@ -2,7 +2,7 @@ import { rollup } from "rollup";
 import path from "path";
 import benchmarkRollup from "./rollup-plugin-benchmark-import";
 import { generateDefaultHTML } from "./html-templating";
-import { buildStateMessager } from "@best/messager";
+import { BuildStateMessager } from "@best/messager";
 import fs from "fs";
 import crypto from "crypto";
 
@@ -26,8 +26,8 @@ function addResolverPlugins({ plugins }) {
     });
 }
 
-export async function buildBenchmark(entry, projectConfig, globalConfig) {
-    buildStateMessager.onBenchmarkBuildStart(entry);
+export async function buildBenchmark(entry, projectConfig, globalConfig, messager) {
+    messager.onBenchmarkBuildStart(entry);
 
     const ext = path.extname(entry);
     const benchmarkName = path.basename(entry, ext);
@@ -53,7 +53,7 @@ export async function buildBenchmark(entry, projectConfig, globalConfig) {
     const html = generateDefaultHTML({ benchmarkJS : `./${benchmarkJSFileName}`, benchmarkName });
     fs.writeFileSync(htmlPath, html, 'utf8');
 
-    buildStateMessager.onBenchmarkBuildEnd(entry);
+    messager.onBenchmarkBuildEnd(entry);
 
     return {
         benchmarkName,
@@ -65,6 +65,6 @@ export async function buildBenchmark(entry, projectConfig, globalConfig) {
     };
 }
 
-export async function buildBenchmarks(tests, projectConfig, globalConfig) {
-    return Promise.all(tests.map(test => buildBenchmark(test, projectConfig, globalConfig)));
+export async function buildBenchmarks(tests, projectConfig, globalConfig, messager) {
+    return Promise.all(tests.map(test => buildBenchmark(test, projectConfig, globalConfig, messager)));
 }

--- a/packages/best-cli/src/run_best.js
+++ b/packages/best-cli/src/run_best.js
@@ -1,7 +1,7 @@
 import globby from "globby";
 import { buildBenchmarks } from "@best/build";
 import { runBenchmarks } from "@best/runner";
-import { buildStateMessager, runnerMessager } from "@best/messager";
+import { BuildStateMessager, RunnerMessager } from "@best/messager";
 import { storeBenchmarkResults } from "@best/store";
 import { analyzeBenchmarks } from "@best/analyzer";
 import path from "path";
@@ -22,10 +22,10 @@ async function getBenchmarkTests(configs, globalConfig) {
     );
 }
 
-async function buildBundleBenchmarks(benchmarksTests, globalConfig) {
+async function buildBundleBenchmarks(benchmarksTests, globalConfig, messager) {
     const bundle = await Promise.all(
         benchmarksTests.map(async ({ matches, config }) =>
-            buildBenchmarks(matches, config, globalConfig))
+            buildBenchmarks(matches, config, globalConfig, messager))
     );
     // Flatten the per-project benchmarks tests
     return bundle.reduce((benchmarks, benchBundle) => {
@@ -41,11 +41,11 @@ async function runBundleBenchmarks(benchmarksBuilds, globalConfig, messager) {
 export async function runBest(globalConfig, configs, outputStream) {
     const benchmarksTests = await getBenchmarkTests(configs, globalConfig);
 
-    buildStateMessager.initBuild(benchmarksTests, globalConfig, outputStream);
-    const benchmarksBuilds = await buildBundleBenchmarks(benchmarksTests, globalConfig);
-    buildStateMessager.finishBuild();
+    const buildMessager = new BuildStateMessager(benchmarksTests, globalConfig, outputStream);
+    const benchmarksBuilds = await buildBundleBenchmarks(benchmarksTests, globalConfig, buildMessager);
+    buildMessager.finishBuild();
 
-    runnerMessager.initRun(benchmarksBuilds, globalConfig, outputStream);
+    const runnerMessager = new RunnerMessager(benchmarksBuilds, globalConfig, outputStream);
     const benchmarkBundleResults = await runBundleBenchmarks(benchmarksBuilds, globalConfig, runnerMessager);
     runnerMessager.finishRun();
 

--- a/packages/best-messager/src/__tests__/messager-error.spec.js
+++ b/packages/best-messager/src/__tests__/messager-error.spec.js
@@ -1,0 +1,25 @@
+import { PassThrough } from 'stream';
+import { errorMessager } from '../index';
+
+const MSG = 'I am an error';
+const { stack } = new Error(MSG);
+
+test('print error in passed stream', () => {
+    const stream = new PassThrough();
+    errorMessager.print(MSG, stack, stream);
+
+    const message = stream.read().toString();
+    expect(message).toMatch(MSG);
+    expect(message).toMatch(stack);
+});
+
+test('print error on process.stdout', () => {
+    const spy = jest.spyOn(process.stdout, 'write').mockImplementation(() => {});
+
+    errorMessager.print(MSG, stack);
+
+    expect(spy).toHaveBeenCalled();
+
+    spy.mockReset();
+    spy.mockRestore();
+});

--- a/packages/best-messager/src/__tests__/messager-pre-run.spec.js
+++ b/packages/best-messager/src/__tests__/messager-pre-run.spec.js
@@ -1,0 +1,71 @@
+import { PassThrough } from 'stream';
+
+const MSG = 'I am a message';
+
+beforeEach(() => {
+    jest.resetModules();
+});
+
+describe('interactive', () => {
+    test('clearLine', () => {
+        const clearLine = jest.fn();
+        jest.doMock('@best/utils', () => {
+            return {
+                isInteractive: true,
+                clearLine,
+            };
+        });
+
+        const { preRunMessager } = require('../index');
+        const stream = new PassThrough();
+
+        preRunMessager.clear(stream);
+        expect(clearLine).toHaveBeenCalledWith(stream);
+    });
+
+    test('print', () => {
+        jest.doMock('@best/utils', () => {
+            return {
+                isInteractive: true,
+            };
+        });
+
+        const { preRunMessager } = require('../index');
+        const stream = new PassThrough();
+
+        preRunMessager.print(MSG, stream);
+        expect(stream.read().toString()).toMatch(MSG);
+    });
+});
+
+describe('not interactive', () => {
+    test('clearLine', () => {
+        const clearLine = jest.fn();
+        jest.doMock('@best/utils', () => {
+            return {
+                isInteractive: false,
+                clearLine,
+            };
+        });
+
+        const { preRunMessager } = require('../index');
+        const stream = new PassThrough();
+
+        preRunMessager.clear(stream);
+        expect(clearLine).not.toHaveBeenCalled();
+    });
+
+    test('print', () => {
+        jest.doMock('@best/utils', () => {
+            return {
+                isInteractive: false,
+            };
+        });
+
+        const { preRunMessager } = require('../index');
+        const stream = new PassThrough();
+
+        preRunMessager.print(MSG, stream);
+        expect(stream.read()).toBe(null);
+    });
+});

--- a/packages/best-messager/src/index.js
+++ b/packages/best-messager/src/index.js
@@ -1,6 +1,7 @@
-import * as preRunMessager from "./messager-pre-run";
-import buildStateMessager from "./messager-build-state";
-import runnerMessager from "./messager-runner";
-import * as errorMessager from "./messager-error";
+import * as preRunMessager from './messager-pre-run';
+import * as errorMessager from './messager-error';
 
-export { preRunMessager, buildStateMessager, runnerMessager, errorMessager };
+import BuildStateMessager from './messager-build-state';
+import RunnerMessager from './messager-runner';
+
+export { preRunMessager, errorMessager, BuildStateMessager, RunnerMessager };

--- a/packages/best-messager/src/messager-build-state.js
+++ b/packages/best-messager/src/messager-build-state.js
@@ -41,31 +41,14 @@ const clearStream = (buffer) => {
     return '\r\x1B[K\r\x1B[1A'.repeat(height);
 };
 
+export default class BuildStateMessager {
+    constructor(benchmarksBundle, globalConfig, outputStream) {
+        this._bufferStream = [];
 
-export default ({
-    _state: null,
-    _out: null,
-    _bufferStream: [],
-
-    // In order to preserve other writes we need to wrap/unwrap the stream
-    // so we can manage how to clear/update
-    _wrapStream(stream) {
-        const _write = stream.write;
-        stream.write = (buffer) => {
-            this._bufferStream.push(buffer);
-            _write.call(stream, buffer);
-        };
-        stream.write._original = _write;
-    },
-    _unwrapStream(stream) {
-        if (stream.write._original) {
-            stream.write = stream.write._original;
-        }
-    },
-    initBuild(benchmarksBundle, globalConfig, outputStream) {
         this._out = outputStream.write.bind(outputStream);
         this._wrapStream(process.stderr);
         this._wrapStream(process.stdout);
+
         const benchmarksState = benchmarksBundle.reduce((map, { config, matches }) => {
             matches.forEach((benchmarkPath) => {
                 map[benchmarkPath] = {
@@ -77,23 +60,45 @@ export default ({
         }, {});
 
         this._state = { benchmarks: benchmarksState, buffer: '', clear: '' };
+
         this._update();
-    },
+    }
+
+    // In order to preserve other writes we need to wrap/unwrap the stream
+    // so we can manage how to clear/update
+    _wrapStream(stream) {
+        const _write = stream.write;
+        stream.write = (buffer) => {
+            this._bufferStream.push(buffer);
+            _write.call(stream, buffer);
+        };
+        stream.write._original = _write;
+    }
+
+    _unwrapStream(stream) {
+        if (stream.write._original) {
+            stream.write = stream.write._original;
+        }
+    }
+
     onBenchmarkBuildStart(id) {
         const bench = this._state.benchmarks[id];
         bench.state = BUILD_STATE.BUILDING;
         this._update();
-    },
+    }
+
     onBenchmarkBuildEnd(id) {
         const bench = this._state.benchmarks[id];
         bench.state = BUILD_STATE.DONE;
         this._update();
-    },
+    }
+
     finishBuild() {
         this._update(true);
         this._unwrapStream(process.stderr);
         this._unwrapStream(process.stdout);
-    },
+    }
+
     _update(force) {
         if (isInteractive || force) {
             const _externalBuffer = this._bufferStream.join('');
@@ -105,10 +110,12 @@ export default ({
 
             this._out(_externalBuffer);
         }
-    },
+    }
+
     _clear() {
         this._out(this._state.clear);
-    },
+    }
+
     _write() {
         const benchmarks = this._state.benchmarks;
         const buffer = Object.keys(benchmarks).reduce((str, key) => {
@@ -120,4 +127,4 @@ export default ({
         this._state.clear = clearStream(buffer);
         this._out(buffer);
     }
-});
+}

--- a/packages/best-messager/src/messager-pre-run.js
+++ b/packages/best-messager/src/messager-pre-run.js
@@ -1,15 +1,14 @@
+import chalk from 'chalk';
 import { clearLine, isInteractive } from '@best/utils';
 
-import chalk from 'chalk';
-
-export const print = (message, stream) => {
+export function print(message, stream) {
     if (isInteractive) {
         stream.write(chalk.bold.dim(message));
     }
-};
+}
 
-export const clear = (stream) => {
+export function clear(stream) {
     if (isInteractive) {
         clearLine(stream);
     }
-};
+}

--- a/packages/best-messager/src/messager-runner.js
+++ b/packages/best-messager/src/messager-runner.js
@@ -95,13 +95,11 @@ const clearStream = (buffer) => {
     return '\r\x1B[K\r\x1B[1A'.repeat(height);
 };
 
-export default ({
-    _state: null,
-    _out: null,
-    _running: false,
-
-    initRun(benchmarksBundle, globalConfig, outputStream) {
+export default class RunnerMessager {
+    constructor(benchmarksBundle, globalConfig, outputStream) {
+        this._running = false;
         this._out = outputStream.write.bind(outputStream);
+
         const benchmarksState = benchmarksBundle.reduce((map, { benchmarkName, benchmarkEntry, projectConfig }) => {
             map[benchmarkName] = {
                 state: BUILD_STATE.QUEUED,
@@ -118,8 +116,10 @@ export default ({
             benchmarks: benchmarksState,
             buffer: ''
         };
+
         this._write();
-    },
+    }
+
     onBenchmarkStart(benchmarkName, overrideOpts) {
         this._running = benchmarkName;
         const bench = this._state.benchmarks[benchmarkName];
@@ -128,20 +128,24 @@ export default ({
         }
         bench.state = BUILD_STATE.RUNNING;
         this._update();
-    },
+    }
+
     updateBenchmarkProgress(state, opts) {
         this._state.progress = generateProgressState(state, opts);
         this._debounceUpdate();
-    },
+    }
+
     onBenchmarkEnd(benchmarkName) {
         this._running = null;
         const bench = this._state.benchmarks[benchmarkName];
         bench.state = BUILD_STATE.DONE;
         this._update();
-    },
+    }
+
     finishRun() {
         this._update(true);
-    },
+    }
+
     _debounceUpdate() {
         if (!this._queued) {
             this._queued = true;
@@ -152,16 +156,19 @@ export default ({
                 }
             }, 300);
         }
-    },
+    }
+
     _update(force) {
         if (isInteractive || force) {
             this._clear();
             this._write();
         }
-    },
+    }
+
     _clear() {
         this._out(this._state.clear);
-    },
+    }
+
     _write() {
         const progress = this._state.progress;
         const benchmarks = this._state.benchmarks;
@@ -187,4 +194,4 @@ export default ({
         this._state.clear = clearStream(buffer);
         this._out(buffer);
     }
-});
+}


### PR DESCRIPTION
**Changes:**
* Add tests for `best-build`
* Decouple `best-messager` from `best-build`. The messager is now passed as parameter instead of relying on a singleton

Related to #21