### PR TITLE
build(packages): Use stand-alone conventional-changelog instead of ler…

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,14 +15,18 @@
     "watch": "yarn build && node ./scripts/watch.js",
     "test": "jest --config jest.config.json",
     "perf:example": "cd examples/simple_benchmark && best --externalStorage=@best/store-aws",
-    "release": "yarn prepare && lerna publish --conventional-commits --exact --force-publish=* --registry='https://npm.lwcjs.org'",
-    "release:internal": "yarn prepare && lerna publish --exact --force-publish=* --skip-git --repo-version `node -pe \"require('./lerna.json').version\"` --yes --registry='https://nexus.soma.salesforce.com/nexus/content/repositories/npmjs-internal/'"
+    "release": "yarn prepare && lerna publish --exact --force-publish=* --registry='https://npm.lwcjs.org' && yarn changelog",
+    "release:internal": "yarn prepare && lerna publish --exact --force-publish=* --skip-git --repo-version `node -pe \"require('./lerna.json').version\"` --yes --registry='https://nexus.soma.salesforce.com/nexus/content/repositories/npmjs-internal/'",
+    "changelog": "yarn changelog:generate && yarn changelog:publish",
+    "changelog:generate": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0",
+    "changelog:publish": "git add CHANGELOG.md && git commit -m 'docs(changelog): publish release changelog' && git push"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "chalk": "^2.3.0",
     "commitizen": "^2.9.6",
+    "conventional-changelog-cli": "^1.3.5",
     "eslint": "^4.14.0",
     "eslint-plugin-lwc": "^0.2.4",
     "jest": "^22.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1614,7 +1614,7 @@ conventional-changelog-atom@^0.1.2:
   dependencies:
     q "^1.4.1"
 
-conventional-changelog-cli@^1.3.2:
+conventional-changelog-cli@^1.3.2, conventional-changelog-cli@^1.3.5:
   version "1.3.5"
   resolved "http://npm.lwcjs.org/conventional-changelog-cli/-/conventional-changelog-cli-1.3.5/46c51496216b7406588883defa6fac589e9bb31e.tgz#46c51496216b7406588883defa6fac589e9bb31e"
   dependencies:


### PR DESCRIPTION
…na to prevent version auto-incr

## PR Checklist

**What kind of change does this PR introduce?** (add 'x' - [x])

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:
Please check if your PR fulfills the following requirements:

**The PR fulfills these requirements:**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Both unit and integration tests pass
- [X] Docs have been added / updated (for bug fixes / features)
- [ ] The PR title follows conventional commit format:
      ```
            commit-type(optional scope): commit description.
      ```
      
      Supported commit types: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test.
      Supported scope: The scope should be the name of the npm package affected (engine, compiler, wire-service, etc.)
      
      
 - More details on LWC semantic commit can be found [here](https://git.soma.salesforce.com/lwc/lwc/blob/master/CONTRIBUTING.md#commit).
      
      

#### Other information:
Do not use lerna's built in conventional-commits due to its default version auto-increment . Instead, use conventional-changelog ( see more details [here](https://github.com/salesforce/lwc/issues/8) )

