### PR TITLE
docs(github): sync pr template with lwc repo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,8 @@
-## PR Checklist
 
-**What kind of change does this PR introduce?** (add 'x' - [x])
+## Details
 
-* [ ] Bugfix
-* [ ] Feature
-* [ ] Code style update (formatting, local variables)
-* [ ] Refactoring (no functional changes, no api changes)
-* [ ] Build related changes
-* [ ] CI related changes
-* [ ] Documentation content changes
-* [ ] Other... Please describe:
 
-**Does this PR introduce a breaking change?** (check one)
+## Does this PR introduce a breaking change?
 
 * [ ] Yes
 * [ ] No
@@ -19,17 +10,20 @@
 If yes, please describe the impact and migration path for existing applications:
 Please check if your PR fulfills the following requirements:
 
-**The PR fulfills these requirements:**
 
-* [ ] Tests for the changes have been added (for bug fixes / features)
-* [ ] Both unit and integration tests pass
-* [ ] Docs have been added / updated (for bug fixes / features)
-* [ ] The PR title follows conventional commit format:
-      `commit-type(optional scope): commit description.`
+## Reminders ( please delete this section before submitting )
+-------------------------------------------------------------
 
-             Supported commit types: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test.
-            Supported scope: The scope should be the name of the npm package affected (engine, compiler, wire-service, etc.)
+### The PR fulfills these requirements:
+* Tests for the changes have been added (for bug fixes / features)
+* Docs have been added / updated (for bug fixes / features)
 
-- More details on LWC semantic commit can be found [here](https://git.soma.salesforce.com/lwc/lwc/blob/master/CONTRIBUTING.md#commit).
+### PR Title
+LWC PR title follows [conventional commit](../CONTRIBUTING.md#create-a-pull-request) format and is automatically validated by our CI.
+```shell
+ex:
+commit-type(optional scope): commit description. ( NOTE: space between column and the message )
 
-#### Other information:
+Types: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test, proposal.
+Scope: The scope should be the name of the npm package affected (engine, compiler, wire-service, etc.)
+```


### PR DESCRIPTION
Copying over pr template into best repo to be in sync with lwc

## PR Checklist

**What kind of change does this PR introduce?** (add 'x' - [x])

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Other... Please describe:

**Does this PR introduce a breaking change?** (check one)

* [ ] Yes
* [ ] No

If yes, please describe the impact and migration path for existing applications:
Please check if your PR fulfills the following requirements:

**The PR fulfills these requirements:**

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Both unit and integration tests pass
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] The PR title follows conventional commit format:
      `commit-type(optional scope): commit description.`

             Supported commit types: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test.
            Supported scope: The scope should be the name of the npm package affected (engine, compiler, wire-service, etc.)

- More details on LWC semantic commit can be found [here](https://git.soma.salesforce.com/lwc/lwc/blob/master/CONTRIBUTING.md#commit).

#### Other information:
