### PR TITLE
ci(all): Make sure yarn.lock is in sync

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
           keys:
           - yarn-v3-{{ checksum "yarn.lock" }}
 
-      - run: yarn install
+      - run: yarn install --frozen-lockfile
       - run: yarn lint
       - run: yarn test
 


### PR DESCRIPTION
## Details

If a contributor updates a dependency manually without running yarn, the yarn.lock will get out-of-sync. This PR adds a check in the CI process to ensure that yarn.lock is always in sync with the package.json.

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No