### PR TITLE
feat(best): very simple customizable test template

### DIFF
--- a/packages/best-build/package.json
+++ b/packages/best-build/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@best/messager": "0.5.0",
     "@best/runtime": "0.5.0",
-    "rollup": "~0.53.0"
+    "rollup": "~0.53.0",
+    "ncp": "^2.0.0"
   }
 }

--- a/packages/best-build/src/__tests__/best-build.spec.js
+++ b/packages/best-build/src/__tests__/best-build.spec.js
@@ -5,15 +5,21 @@ import * as path from 'path';
 import { buildBenchmark } from '../index';
 
 const TEMP_DIR_PREFIX = 'best-test-';
+const ROOT_DIR_PREFIX = 'best-root-test-';
 const MOCK_MESSAGER = {
     onBenchmarkBuildStart() {},
     onBenchmarkBuildEnd() {},
     logState() {}
 };
 const projectName = 'test';
+const rootDir = roorDir();
 
 function tempDir() {
     return fs.mkdtempSync(path.join(os.tmpdir(), TEMP_DIR_PREFIX));
+}
+
+function roorDir() {
+    return fs.mkdtempSync(path.join(os.tmpdir(), ROOT_DIR_PREFIX));
 }
 
 describe('buildBenchmark', () => {
@@ -23,7 +29,8 @@ describe('buildBenchmark', () => {
             path.resolve(__dirname, 'fixtures', 'single-file', 'single-file.js'),
             {
                 cacheDirectory,
-                projectName
+                projectName,
+                rootDir
             },
             {},
             MOCK_MESSAGER,
@@ -39,7 +46,8 @@ describe('buildBenchmark', () => {
             path.resolve(__dirname, 'fixtures', 'single-file', 'single-file.js'),
             {
                 cacheDirectory: tempDir(),
-                projectName
+                projectName,
+                rootDir
             },
             {},
             MOCK_MESSAGER,
@@ -62,8 +70,8 @@ describe('buildBenchmark', () => {
             path.resolve(__dirname, 'fixtures', 'single-file', 'single-file.js'),
             {
                 cacheDirectory: tempDir(),
-                projectName
-
+                projectName,
+                rootDir
             },
             {},
             messager,
@@ -99,6 +107,7 @@ describe('buildBenchmark', () => {
                 cacheDirectory: tempDir(),
                 projectName,
                 plugins: [['build-plugin-opts', PLUGIN_OPTIONS]],
+                rootDir
             },
             {},
             MOCK_MESSAGER,
@@ -135,6 +144,7 @@ describe('buildBenchmark', () => {
                 cacheDirectory: tempDir(),
                 projectName,
                 plugins: ['build-plugin-hooks'],
+                rootDir
             },
             {},
             MOCK_MESSAGER,

--- a/packages/best-build/src/html-templating.js
+++ b/packages/best-build/src/html-templating.js
@@ -18,5 +18,9 @@ export function generateParametrizedHTML(html, options) {
 }
 
 export function generateDefaultHTML(options) {
-    return generateParametrizedHTML(DEFAULT_HTML, options);
+    let template = DEFAULT_HTML;
+    if (Object.keys(options).indexOf("customTemplate") > -1) {
+        template = options.customTemplate;
+    }
+    return generateParametrizedHTML(template, options);
 }


### PR DESCRIPTION
## Details
This change allows a tests to customize the base test template when test runs are built.  This change is required to allow Aura (and any other non modularized JS library) to be inserted, loaded and eval'ed by the browser when the test runs.


## Does this PR introduce a breaking change?

* [x] No

Happy to hear about alternate ideas here

cc/ @diervo