### PR TITLE
fix: added meta tag with highest doc mode support in IE

### DIFF
--- a/packages/best-build/src/html-templating.js
+++ b/packages/best-build/src/html-templating.js
@@ -9,6 +9,7 @@ const DEFAULT_HTML = `<!DOCTYPE html>
 <html>
   <head>
     <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>{{benchmarkName}}</title>
   </head>
   <body>


### PR DESCRIPTION
## Details
IE11 does not always remember the document mode setting when set via Developer Tools. This meta tag ensures that IE would always run in the latest version.

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No