### PR TITLE
feat: added option to ignore test paths via config

### DIFF
--- a/packages/best-cli/src/run_best.js
+++ b/packages/best-cli/src/run_best.js
@@ -16,7 +16,8 @@ const IGNORE_PATHS = [
 async function getBenchmarkPaths({ rootDir }, config) {
     const { testMatch, rootDir: projectRoot } = config;
     const cwd = projectRoot || rootDir;
-    const results = await globby(testMatch, { cwd, ignore: IGNORE_PATHS });
+    const ignorePaths = IGNORE_PATHS.concat(config.testPathIgnorePatterns || []);
+    const results = await globby(testMatch, { cwd, ignore: ignorePaths });
     return results.map(p => path.resolve(cwd, p));
 }
 


### PR DESCRIPTION
## Details
This change allows ignore patterns to be specified in the config file.  When patterns are specified, any benchmark file or folder that matches will be excluded from running the test.

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No