### PR TITLE
fix: allow any benchmark name

### DIFF
--- a/packages/best-analyzer/src/index.js
+++ b/packages/best-analyzer/src/index.js
@@ -19,7 +19,11 @@ function computeSampleStats(arr, config) {
 }
 
 function collectResults({ name, duration, runDuration, benchmarks }, collector) {
-    const cNode = collector[name] || (collector[name] = { duration: [], runDuration: [] });
+    let cNode = collector[name];
+    if (typeof cNode !== 'object') {
+        cNode = collector[name] = { duration: [], runDuration: [] };
+    }
+
     if (duration > 0) {
         cNode.duration.push(duration);
     }


### PR DESCRIPTION
## Fixes
When benchmarking several methods in a class (including the constructor), you might want to use the name "constructor" for a child benchmark. If you do, the benchmark runs successfully, but best-analyzer fails to collect results because it thinks that `collector['constructor']` has already been defined. This fixes that issue by requiring collector nodes to be objects.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No