### PR TITLE
fix: don't overwrite error messages

### DIFF
--- a/packages/best-runtime/src/utils/validate.js
+++ b/packages/best-runtime/src/utils/validate.js
@@ -1,10 +1,19 @@
 export function validateState(benchmarkState) {
-    const { rootDescribeBlock, currentDescribeBlock } = benchmarkState;
+    const {
+        rootDescribeBlock,
+        currentDescribeBlock,
+        benchmarkDefinitionError
+    } = benchmarkState;
+
+    if (benchmarkDefinitionError) {
+        return; // Nothing to do; there is already an error
+    }
+
     if (rootDescribeBlock !== currentDescribeBlock) {
-        benchmarkState.benchmarkDefinitionError = 'Benchmark parsing error';
+        benchmarkState.benchmarkDefinitionError = new Error('Benchmark parsing error');
     }
 
     if (rootDescribeBlock.children === 0) {
-        benchmarkState.benchmarkDefinitionError = 'No benchmarks to run';
+        benchmarkState.benchmarkDefinitionError = new Error('No benchmarks to run');
     }
 }


### PR DESCRIPTION
## Details

Without this PR, you might get an error that looks like this:

![screen shot 2019-01-30 at 10 54 13 am](https://user-images.githubusercontent.com/283842/52004977-670e1980-247d-11e9-94c2-9694692d903c.png)

With this PR, the same error would look like this:

![screen shot 2019-01-30 at 10 54 31 am](https://user-images.githubusercontent.com/283842/52004989-71301800-247d-11e9-9540-4a171dab4f98.png)

The problem is that the `validate()` function may overwrite the existing error, with a string. This PR also fixes it so that the error is an actual `Error`, because later on this error gets `throw`n and it doesn't make any sense to throw a string.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No