### PR TITLE
fix: remove duration from github agent comment 

### DIFF
--- a/packages/best-github-integration/src/__tests__/fixtures/expected1.md
+++ b/packages/best-github-integration/src/__tests__/fixtures/expected1.md
@@ -7,14 +7,14 @@ Base commit: `abcdef0` | Target commit: `1234567`
 
 ## *Project Foo*
 
-foo.js | metric | base(`abcdef0`) | target(`1234567`) | trend
---- | --- | --- | --- | ---
-Foo Test 1 | duration | 3000.00 (±2.00 ms) | 4000.00 (±3.00 ms) | +1000.0ms (33.3%) 👎
-Foo Test 2 | duration | 7000.00 (±-3.25 ms) | 5000.00 (±7.30 ms) | -2000.0ms (28.6%) 👍
+foo.js | base(`abcdef0`) | target(`1234567`) | trend
+--- | --- | --- | ---
+Foo Test 1 | 3000.00 (±2.00 ms) | 4000.00 (±3.00 ms) | +1000.0ms (33.3%) 👎
+Foo Test 2 | 7000.00 (±-3.25 ms) | 5000.00 (±7.30 ms) | -2000.0ms (28.6%) 👍
 
 ## *Project Bar*
 
-bar.js | metric | base(`abcdef0`) | target(`1234567`) | trend
---- | --- | --- | --- | ---
-Bar Test 1 | duration | 1000.00 (±-1.00 ms) | 2000.00 (±-2.78 ms) | +1000.0ms (100.0%) 👎
+bar.js | base(`abcdef0`) | target(`1234567`) | trend
+--- | --- | --- | ---
+Bar Test 1 | 1000.00 (±-1.00 ms) | 2000.00 (±-2.78 ms) | +1000.0ms (100.0%) 👎
 </details>

--- a/packages/best-github-integration/src/comment.js
+++ b/packages/best-github-integration/src/comment.js
@@ -44,7 +44,6 @@ function generateRows(stats, name = '', rows = []) {
 
             allRows.push([
                 name + node.name,
-                'duration',
                 `${baseMed.toFixed(2)} (±${baseStats.medianAbsoluteDeviation.toFixed(2)} ms)`,
                 `${targetMed.toFixed(2)} (±${targetStats.medianAbsoluteDeviation.toFixed(2)} ms)`,
                 sign + relativeTrend.toFixed(1) + 'ms (' + percentage.toFixed(1) + '%) ' + (samplesComparison === 0 ? '👌' : samplesComparison === 1 ? '👎' : '👍'),
@@ -59,7 +58,7 @@ function generateTable(baseCommit, targetCommit, stats) {
     const mdName = benchmarkName.replace('.benchmark', '');
     return {
         table: {
-            headers: [`${mdName}`, 'metric', `base(\`${baseCommit}\`)`, `target(\`${targetCommit}\`)`, 'trend'],
+            headers: [`${mdName}`, `base(\`${baseCommit}\`)`, `target(\`${targetCommit}\`)`, 'trend'],
             rows: generateRows(stats),
             projectName
         },


### PR DESCRIPTION
## Details

The "metric" column with the value "duration" is currently hardcoded in the output of the Best GitHub agent. This creates a lot of noise, and doesn't add any information, since it is a hard-coded value.

This PR removes it. The result looks like this:

![screen shot 2019-01-30 at 4 38 26 pm](https://user-images.githubusercontent.com/283842/52022486-f16e7180-24ad-11e9-8f7c-db91ce7aba5d.png)

This PR is rebased on top of #135 to avoid bitrotting myself.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No