### PR TITLE
chore: remove beforeEach and afterEach hooks

### DIFF
--- a/packages/@best/builder/src/rollup-plugin-benchmark-import.ts
+++ b/packages/@best/builder/src/rollup-plugin-benchmark-import.ts
@@ -2,10 +2,8 @@ import {InputOption, RollupOptions} from "rollup";
 
 const PRIMITIVES = [
     'beforeAll',
-    'beforeEach',
     'before',
     'afterAll',
-    'afterEach',
     'after',
     'benchmark',
     'describe',

--- a/packages/@best/runtime/src/constants.ts
+++ b/packages/@best/runtime/src/constants.ts
@@ -1,8 +1,6 @@
 const BEFORE_ALL = 'beforeAll';
-const BEFORE_EACH = 'beforeEach';
 const BEFORE = 'before';
 const AFTER_ALL = 'afterAll';
-const AFTER_EACH = 'afterEach';
 const AFTER = 'after';
 
 const MODE_ONLY = 'only';
@@ -11,10 +9,8 @@ const MODE_SKIP = 'skip';
 export const MODES = { ONLY: MODE_ONLY, SKIP: MODE_SKIP };
 export const HOOKS = {
     BEFORE_ALL,
-    BEFORE_EACH,
     BEFORE,
     AFTER_ALL,
-    AFTER_EACH,
     AFTER,
 };
 export const RUN_BENCHMARK = 'run_benchmark';

--- a/packages/@best/runtime/src/primitives.ts
+++ b/packages/@best/runtime/src/primitives.ts
@@ -23,11 +23,9 @@ benchmark.skip = (benchmarkName: string, fn: Function) => _dispatchBenchmark(ben
 
 const _addHook = (fn: Function, hookType: string) => dispatch({ nodeName: 'hook', fn, hookType, nodeType: 'add_hook' });
 const beforeAll = (fn: Function) => _addHook(fn, HOOKS.BEFORE_ALL);
-const beforeEach = (fn: Function) => _addHook(fn, HOOKS.BEFORE_EACH);
 const before = (fn: Function) => _addHook(fn, HOOKS.BEFORE);
 const afterAll = (fn: Function) => _addHook(fn, HOOKS.AFTER_ALL);
-const afterEach = (fn: Function) => _addHook(fn, HOOKS.AFTER_EACH);
 const after = (fn: Function) => _addHook(fn, HOOKS.AFTER);
 const run = (fn: Function) => dispatch({ nodeName: 'run', fn, nodeType: RUN_BENCHMARK });
 
-export { describe, benchmark, beforeAll, beforeEach, before, afterAll, afterEach, after, run };
+export { describe, benchmark, beforeAll, before, afterAll, after, run };

--- a/packages/@best/runtime/src/run_iteration.ts
+++ b/packages/@best/runtime/src/run_iteration.ts
@@ -80,20 +80,10 @@ export const runBenchmarkIteration = async (node: RuntimeNode, opts: { useMacroT
     // -- For each children ----
     if (children) {
         for (const child of children) {
-            // -- Before Each ----
-            for (const hook of hookHandlers[HOOKS.BEFORE_EACH]) {
-                await hook();
-            }
-
             // -- Traverse Child ----
             node.startedAt = formatTime(time());
             await runBenchmarkIteration(child, opts);
             node.aggregate = formatTime(time() - node.startedAt);
-
-            // -- After Each Child ----
-            for (const hook of hookHandlers[HOOKS.AFTER_EACH]) {
-                await hook();
-            }
         }
     }
 


### PR DESCRIPTION
## Details

This removes the `beforeEach` and `afterEach` hooks for benchmarks. You need to use `before` and `after` instead.

This addresses #142.

## Does this PR introduce a breaking change?
* Yes