### PR TITLE
fix: only show summary when not empty

### DIFF
--- a/packages/@best/github-integration/src/analyze.ts
+++ b/packages/@best/github-integration/src/analyze.ts
@@ -138,10 +138,14 @@ function generateCommentWithTables(result: BenchmarkComparison, handler: (node: 
         if (node.type === "project" || node.type === "group") {
             const markdownTables = handler(node, baseCommit, targetCommit);
 
-            return {
-                ...tables,
-                [node.name]: markdownTables
+            if (markdownTables.length) {
+                return {
+                    ...tables,
+                    [node.name]: markdownTables
+                }
             }
+
+            return tables;
         }
 
         return tables;


### PR DESCRIPTION
## Details

Only shows project name when there are results to show.