### PR TITLE
fix: projects option

### DIFF
--- a/packages/@best/cli/src/cli/index.ts
+++ b/packages/@best/cli/src/cli/index.ts
@@ -22,7 +22,7 @@ export function buildArgs(maybeArgv?: string[]): CliConfig {
 }
 
 function getProjectListFromCLIArgs(argsCLI: CliConfig, project?: string): string[] {
-    const projects = argsCLI.projects;
+    const projects = argsCLI.projects.slice();
 
     if (project) {
         projects.push(project);

--- a/packages/@best/config/src/index.ts
+++ b/packages/@best/config/src/index.ts
@@ -112,7 +112,6 @@ export async function getConfigs(projectsFromCLIArgs: string[], cliOptions: CliC
         const parsedConfigs = await Promise.all(projects.map(root => readConfig(cliOptions, root, configPath)));
         ensureNoDuplicateConfigs(parsedConfigs, projects);
         configs = parsedConfigs.map(({ projectConfig }) => projectConfig);
-        globalConfig = parsedConfigs[0].globalConfig;
     }
 
     if (!globalConfig) {

--- a/packages/@best/config/src/utils/normalize.ts
+++ b/packages/@best/config/src/utils/normalize.ts
@@ -70,6 +70,11 @@ function setCliOptionOverrides(initialOptions: UserConfig, argsCLI: CliConfig): 
                 case 'runInBatch':
                     options.runInBatch = !!argsCLI[key];
                     break;
+                case 'projects':
+                    if (argsCLI.projects && argsCLI.projects.length) {
+                        options.projects = argsCLI.projects;
+                    }
+                    break;
                 case 'compareStats':
                     options.compareStats = argsCLI.compareStats && argsCLI.compareStats.filter(Boolean);
                     break;
@@ -92,7 +97,7 @@ function setCliOptionOverrides(initialOptions: UserConfig, argsCLI: CliConfig): 
             }
             return options;
         }, {});
-    
+
     return { ...initialOptions, ...argvToOptions };
 }
 function normalizeObjectPathPatterns(options: { [key: string]: any }, rootDir: string) {


### PR DESCRIPTION
## Details

When using the projects option, the configuration merged was incorrectly overriding the user land values.
