### PR TITLE
feat: add statistic tracking to agent-hub

### DIFF
--- a/packages/@best/agent-frontend/src/client/modules/view/dashboard/dashboard.css
+++ b/packages/@best/agent-frontend/src/client/modules/view/dashboard/dashboard.css
@@ -13,3 +13,31 @@ header {
     border-radius: 4px;
     padding: 8px 0;
 }
+
+.stats {
+    background: #ffe8be;
+    padding: 2px 12px;
+    text-align: right;
+}
+
+.stats:first-of-type {
+    border-radius: 4px 4px 0 0;
+}
+
+.stats:last-of-type {
+    border-radius: 0 0 4px 4px;
+}
+
+.stats span {
+    font-size: 14px;
+    text-align: right;
+    display:inline;
+    padding-right:5px;
+}
+
+.stats .label {
+    font-weight: bold;
+}
+.stats .value {
+    font-size: 12px;
+}

--- a/packages/@best/agent-frontend/src/client/modules/view/dashboard/dashboard.html
+++ b/packages/@best/agent-frontend/src/client/modules/view/dashboard/dashboard.html
@@ -1,5 +1,27 @@
 <template>
     <div class="container">
+        <template if:true={hasHubStats}>
+            <div class="stats">
+                <span class="label">Active Clients:</span>
+                <span class="value">{hubStats.runningClientCount}</span>
+                <span class="label">Pending Clients:</span>
+                <span class="value">{hubStats.pendingClientCount}</span>
+                <span class="label">Queued Jobs:</span>
+                <span class="value">{hubStats.pendingJobCount}</span>
+            </div>
+        </template>
+        <template if:true={hasAgentStats}>
+            <div class="stats">
+                <span class="label">Active Agents:</span>
+                <span class="value">{agentStats.active}</span>
+                <span class="label">Idle Agents:</span>
+                <span class="value">{agentStats.idle}</span>
+                <span class="label">Offline Agents:</span>
+                <span class="value">{agentStats.offline}</span>
+                <span class="label">Total:</span>
+                <span class="value">{agentStats.agents}</span>
+            </div>
+        </template>
         <template for:each={agents} for:item="agent">
             <component-agent key={agent.agentId} name={agent.agentId} jobs={agent.jobs}></component-agent>
         </template>

--- a/packages/@best/agent-frontend/src/client/modules/view/dashboard/dashboard.js
+++ b/packages/@best/agent-frontend/src/client/modules/view/dashboard/dashboard.js
@@ -7,6 +7,8 @@ export default class ViewDashboard extends LightningElement {
     config = { host: window.location.origin, path: '/best' };
 
     @track agents = [];
+    @track hubStats = null;
+    @track agentStats = null;
     allJobs = [];
 
     connectedCallback() {
@@ -23,12 +25,21 @@ export default class ViewDashboard extends LightningElement {
         socket.on('benchmark error', this.error.bind(this));
         socket.on('benchmark cancel', this.cancel.bind(this));
         socket.on('benchmark results', this.results.bind(this));
+        socket.on('stats update', this.stats.bind(this));
     }
 
     // GETTERS
 
     get hasJobs() {
         return this.allJobs.length > 0;
+    }
+
+    get hasHubStats () {
+        return this.hubStats !== null;
+    }
+
+    get hasAgentStats () {
+        return this.agentStats !== null;
     }
 
     // HELPERS
@@ -60,7 +71,7 @@ export default class ViewDashboard extends LightningElement {
         oldAgent.jobs.splice(oldJobIndex, 1);
 
         this.updateAgentsJob(updatedJob);
-    } 
+    }
 
     // SOCKET
 
@@ -104,7 +115,7 @@ export default class ViewDashboard extends LightningElement {
         const index = this.allJobs.findIndex(j => j.jobId === event.jobId);
         const job = this.allJobs[index];
         job.status = 'RUNNING';
-        
+
         if (event.agentId !== job.agentId) {
             const oldAgentId = job.agentId;
             job.agentId = event.agentId;
@@ -145,5 +156,10 @@ export default class ViewDashboard extends LightningElement {
         job.status = 'CANCELLED';
 
         this.updateAgentsJob(job);
+    }
+
+    stats(event) {
+        this.hubStats = event.packet.hub;
+        this.agentStats = event.packet.agentManager;
     }
 }

--- a/packages/@best/agent-frontend/src/server/manager.ts
+++ b/packages/@best/agent-frontend/src/server/manager.ts
@@ -8,7 +8,7 @@
 import socketIO from 'socket.io';
 import AgentLogger from '@best/agent-logger';
 
-const FRONTEND_EVENTS = ['benchmark added', 'benchmark start', 'benchmark update', 'benchmark end', 'benchmark error', 'benchmark results', 'benchmark queued', 'benchmark cancel']
+const FRONTEND_EVENTS = ['benchmark added', 'benchmark start', 'benchmark update', 'benchmark end', 'benchmark error', 'benchmark results', 'benchmark queued', 'benchmark cancel', "stats update"]
 
 export default class Manager {
     private frontends: socketIO.Socket[] = [];

--- a/packages/@best/agent-hub/src/Agent.ts
+++ b/packages/@best/agent-hub/src/Agent.ts
@@ -62,10 +62,12 @@ export class Agent extends EventEmitter {
         if (value !== this._status) {
             const oldValue = this._status;
             this._status = value;
-            this.emit('status-changed', {
+            const packet = {
                 oldValue,
                 newValue: value
-            })
+            }
+            this.emit('status-changed', packet);
+            this._logger.event("AgentManager", "AGENT_STATUS_CHANGED", packet);
         }
     }
 

--- a/packages/@best/agent-hub/src/AgentManager.ts
+++ b/packages/@best/agent-hub/src/AgentManager.ts
@@ -10,6 +10,16 @@ import {Agent, AgentConfig, AgentStatus, Spec} from "./Agent";
 import BenchmarkJob from "./BenchmarkJob";
 import AgentLogger from "@best/agent-logger";
 
+// Wait time 30 minutes
+const REMOVE_OFFLINE_AGENT_WAIT = 1800000;
+
+export interface AgentManagerStatus {
+    agents: number
+    active: number,
+    idle: number,
+    offline: number
+}
+
 export class AgentManager extends EventEmitter {
     private agents: Agent[] = [];
 
@@ -45,20 +55,64 @@ export class AgentManager extends EventEmitter {
         this.addStatusChangeListener(agent);
     }
 
+    removeAgent(agent: Agent) {
+        // remove agent and emit event.
+        this.emit("agent-removed", this.agents.splice(this.agents.indexOf(agent), 1));
+    }
+
+    removeAgentByHostname(agentHost: string) {
+        const agent = this.getAgent(agentHost);
+        if (agent !== null) {
+            this.removeAgent(agent);
+        }
+    }
+
     private addStatusChangeListener = (agent: Agent) => {
         agent.on('status-changed', ({ newValue }: { newValue: AgentStatus }) => {
             if (newValue === AgentStatus.Idle) {
                 this.emit('idle-agent', agent);
+            } else if (newValue === AgentStatus.Offline) {
+                setTimeout(() => {
+                    // remove the agent after a specific amount of time if it remains offline.
+                    if (agent.status === AgentStatus.Offline) {
+                        this.removeAgent(agent);
+                    }
+                }, REMOVE_OFFLINE_AGENT_WAIT)
             }
         });
     };
 
-    getAgent(agentHost: string) {
+    getAgent(agentHost: string): Agent | null {
         let i: number = 0;
 
         while (i < this.agents.length && this.agents[i].host !== agentHost) i++;
 
         return i < this.agents.length ? this.agents[i] : null;
+    }
+
+    getAgentsStatus() : AgentManagerStatus {
+        const ret: AgentManagerStatus = {
+            agents: this.agents.length,
+            active: 0,
+            idle: 0,
+            offline: 0,
+        }
+
+        this.agents.forEach(agent => {
+            switch(agent.status) {
+                case AgentStatus.Idle:
+                    ret.idle++;
+                    break;
+                case AgentStatus.Offline:
+                    ret.offline++;
+                    break;
+                case AgentStatus.RunningJob:
+                    ret.active++;
+                    break;
+            }
+        })
+
+        return ret;
     }
 }
 

--- a/packages/@best/agent-hub/src/StatsManager.ts
+++ b/packages/@best/agent-hub/src/StatsManager.ts
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+*/
+
+import { EventEmitter } from "events";
+import { HubApplication, HubStatus } from "./HubApplication";
+import { AgentManager, AgentManagerStatus } from "./AgentManager";
+import AgentLogger from "@best/agent-logger";
+
+
+const THROTTLE_WAIT = 1000;
+
+enum ThrottleKey {
+    ALL_EVENT = 1,
+    CLIENT_EVENT,
+    AGENT_STATUS_EVENT
+}
+
+export enum StatsEvents {
+    STATS_UPDATE = "stats update",
+    HUB_STATS_UPDATE = "stats hub update",
+    AGENT_MANAGER_STATS_UPDATE = "stats agentmanager update"
+}
+
+export interface Stats {
+    hub : HubStatus,
+    agentManager: AgentManagerStatus
+}
+
+/**
+ * Listen to log events to build and manage statistics about the system.
+ */
+export class StatsManager extends EventEmitter {
+    private _app: HubApplication;
+    private _agentManager: AgentManager;
+    private _logger: AgentLogger;
+    private _stats : Stats;
+
+    private _pendingEvents = new Set<ThrottleKey>();
+
+    constructor(app: HubApplication, agentManager: AgentManager, logger: AgentLogger) {
+        super();
+        this._app = app;
+        this._agentManager = agentManager;
+        this._logger = logger;
+
+        // initalize our stats with hub status and AgentManager status.
+        this._stats = {
+            hub: this._app.getLoadStatus(),
+            agentManager: this._agentManager.getAgentsStatus()
+        }
+
+        this.registerExternalEvents();
+        this.registerInternalEvents();
+    }
+
+    /**
+     * Listening to all external events of interest.
+     */
+    private registerExternalEvents() {
+        this._logger.on("CLIENT_CONNECTED", (packet: any) => {
+            this.handleClientEvent()
+        });
+        this._logger.on("CLIENT_DISCONNECTED", (packet: any) => {
+            this.handleClientEvent()
+        });
+        this._logger.on("PENDING_JOB_CHANGED", (packet: any) => {
+            this.handleClientEvent()
+        });
+
+        this._logger.on("AGENT_STATUS_CHANGED", (packet: any) => {
+            this.handleAgentStatusEvent();
+        });
+    }
+
+    /**
+     * Listen to all internally emitted events to emit the full stats.
+     */
+    private registerInternalEvents() {
+        this.on(StatsEvents.HUB_STATS_UPDATE, (packet: any) => {
+            this.emitFullStats();
+        })
+
+        this.on(StatsEvents.AGENT_MANAGER_STATS_UPDATE, (packet: any) => {
+            this.emitFullStats();
+        });
+    }
+
+
+    private throttle(key: ThrottleKey, callback: () => any ) {
+        if (!this._pendingEvents.has(key)) {
+            this._pendingEvents.add(key);
+            setTimeout(() => {
+                callback();
+                this._pendingEvents.delete(key);
+            }, THROTTLE_WAIT)
+        }
+    }
+
+    /**
+     * emit the full stats
+     */
+    private emitFullStats() {
+        this.throttle(ThrottleKey.ALL_EVENT, () => {
+            this.emit(StatsEvents.STATS_UPDATE, this._stats);
+        });
+    }
+
+    /**
+     * get hub status and emit
+     */
+    private handleClientEvent() {
+        this.throttle(ThrottleKey.CLIENT_EVENT, () => {
+            this._stats.hub = this._app.getLoadStatus();
+            this.emit(StatsEvents.HUB_STATS_UPDATE, this._stats.hub);
+        });
+    }
+
+    /**
+     * get agentManager status and emit
+     */
+    private handleAgentStatusEvent() {
+        this.throttle(ThrottleKey.AGENT_STATUS_EVENT, () => {
+            this._stats.agentManager = this._agentManager.getAgentsStatus();
+            this.emit(StatsEvents.AGENT_MANAGER_STATS_UPDATE, this._stats.agentManager);
+        });
+    }
+
+    // Override
+    emit(event: string | symbol, ...args: any[]): boolean {
+        this._logger.event("StatsManager", event.toString(), ...args);
+
+        return super.emit(event, ...args);
+    }
+}
+
+export function createStatsManager(app: HubApplication, agentManager: AgentManager, logger: AgentLogger): StatsManager {
+    return new StatsManager(app, agentManager, logger);
+}

--- a/packages/@best/agent-hub/src/hub-server.ts
+++ b/packages/@best/agent-hub/src/hub-server.ts
@@ -10,6 +10,7 @@ import { Application } from "express";
 import BenchmarkJob from "./BenchmarkJob";
 import ObservableQueue from "./utils/ObservableQueue";
 import { createAgentManager } from "./AgentManager";
+import { createStatsManager } from "./StatsManager";
 import { HubApplication } from "./HubApplication";
 import { AgentConfig } from "./Agent";
 import { configureAgentsApi } from "./agents-api";
@@ -25,7 +26,11 @@ function createHubApplication(config: HubConfig, logger: AgentLogger): HubApplic
     const incomingQueue = new ObservableQueue<BenchmarkJob>();
     const agentsManager = createAgentManager(config.agents, logger);
 
-    return new HubApplication(incomingQueue, agentsManager, logger);
+    const hub = new HubApplication(incomingQueue, agentsManager, logger);
+    createStatsManager(hub, agentsManager, logger);
+
+
+    return hub;
 }
 
 export function runHub(server: any, app: Application, hubConfig: HubConfig) {


### PR DESCRIPTION
## Details
**Added stats tracking with StatsManager to agent-hub:**
For now it begins tracking statistics like number of active/pending clients, total jobs in queue, and active/idle/offline agents by listening to specific log events. This will give us better insight into the server load, and therefore, be able to autoscale better in the cloud.

**Added new behavior to remove agents that are offline for more than 30 minutes:**
Previously, agent-hub has no way to remove offline clients, and after discussing with Jose, I've introduced a new behavior to remove clients that are offline for more than 30 minutes. 

**Modified front-end to display the new stats introduced by StatsManager**
  
![Sep-26-2019 17-07-33](https://user-images.githubusercontent.com/2160274/65797333-d5e26600-e123-11e9-9ac6-28c9784be0cf.gif)


## Does this PR introduce a breaking change?

* [ ] Yes
* [ X] No
