### PR TITLE
fix: webdriverio to work with IE11 and other browsers

### DIFF
--- a/packages/@best/agent-hub/src/Agent.ts
+++ b/packages/@best/agent-hub/src/Agent.ts
@@ -123,7 +123,9 @@ export class Agent extends EventEmitter {
         const remoteAgentRunnerConfig = Object.assign(
             {},
             this._config.remoteRunnerConfig,
-            { host: this._config.host, options: this._config.options }
+            { host: this._config.host,
+                options: this._config.options,
+                webdriverOptions: job.projectConfig.benchmarkRunnerConfig.webdriverOptions }
         );
 
         const overriddenProjectConfig = Object.assign(

--- a/packages/@best/builder/package.json
+++ b/packages/@best/builder/package.json
@@ -19,6 +19,7 @@
     "ncp": "^2.0.0",
     "rimraf": "^2.6.2",
     "rollup": "~1.15.5",
+    "rollup-plugin-compat": "^0.21.7",
     "worker-farm": "~1.7.0"
   },
   "files": [

--- a/packages/@best/runner-webdriverio/src/index.ts
+++ b/packages/@best/runner-webdriverio/src/index.ts
@@ -93,12 +93,11 @@ export default class Runner extends AbstractRunner {
     }
 
     async runIteration(browser: WebdriverBrowser, payload: any): Promise<BenchmarkResults> {
-        return browser.evaluate(async (o: any, done: any) => {
-            try {
-                done(await BEST.runBenchmark(o))
-            } catch(e) {
-                throw e;
-            }
+        return browser.evaluate(function (o: any, done: any) {
+            // Injected code needs to be compatiable with IE11
+            BEST.runBenchmark(o)
+                .then(function(data: any) { done(data); })
+                .catch(function (e: any) { throw e; })
         }, payload);
     }
 }


### PR DESCRIPTION
## Details
Refactored best/runner-webdriverio code and added rollup-plugin-compat dependency for best/builder to fix IE11 compatibility issues.

In my original best/runner-webdriverio PR, I forgot to include this change in Agent.ts which passes the webdriverOptions to the remote agent worker in agent-hub. Without this change, we aren't able to override the default webdriverOptions which has chrome as the default browser.  

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No