### PR TITLE
feat: add job retry on agent connection error

### DIFF
--- a/packages/@best/agent-hub/src/AgentManager.ts
+++ b/packages/@best/agent-hub/src/AgentManager.ts
@@ -32,9 +32,7 @@ export class AgentManager extends EventEmitter {
 
     getIdleAgentForJob(job: BenchmarkJob): Agent | null {
         // @todo: organize Agents by category.
-        const idleAgentsForJob = this.agents.filter(agent => agent.isIdle() && agent.canRunJob(job.spec));
-
-        return idleAgentsForJob.length ? idleAgentsForJob[0] : null;
+        return this.agents.find(agent => agent.isIdle() && agent.canRunJob(job.spec)) || null;
     }
 
     existAgentWithSpec(spec: Spec): boolean {

--- a/packages/@best/agent-hub/src/HubApplication.ts
+++ b/packages/@best/agent-hub/src/HubApplication.ts
@@ -133,7 +133,9 @@ export class HubApplication {
 
         if (agent !== null) {
             this._incomingQueue.remove(job);
-            agent.runJob(job);
+            agent.runJob(job).catch(err => {
+                this._incomingQueue.push(job);
+            });
             this._logger.event("Hub", 'PENDING_JOB_CHANGED');
         } else {
             job.socketConnection.emit('benchmark_enqueued', { pending: this._incomingQueue.size });
@@ -219,7 +221,9 @@ export class HubApplication {
             if (agent.canRunJob(job!.spec)) {
                 this._incomingQueue.remove(job!);
                 this._logger.event("Hub", 'PENDING_JOB_CHANGED');
-                agent.runJob(job!);
+                agent.runJob(job!).catch( (err) => {
+                    this._incomingQueue.push(job!);
+                });
                 break;
             }
         }


### PR DESCRIPTION
## Details
Preemptively check to see if Agent is still alive (calling GET on host) before running each benchmark. If agent is not alive, then the job gets re-added back to the queue for the next agent to handle the job. 

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No