### PR TITLE
fix: rollup multiple chunks issues

### DIFF
--- a/packages/@best/builder/src/build-benchmark.ts
+++ b/packages/@best/builder/src/build-benchmark.ts
@@ -62,7 +62,8 @@ export async function buildBenchmark(entry: string, projectConfig: FrozenProject
     const rollupInputOpts = {
         input: entry,
         plugins: [benchmarkRollup(), ...addResolverPlugins(projectConfig.plugins)],
-        cache: ROLLUP_CACHE.get(projectName)
+        cache: ROLLUP_CACHE.get(projectName),
+        manualChunks: function () { /* guarantee one chunk */ return 'main_chunk'; }
     };
 
     buildLogStream.log('Bundling benchmark files...');


### PR DESCRIPTION
## Details

The new version of rollup might generate multiple chunks if the bundle is too big. For Best we want to avoid this since one bundle is what we want.