### PR TITLE
feat: add autoscale to agent-hub

### DIFF
--- a/packages/@best/agent-hub/src/autoscale-aws/AWSAutoScale.ts
+++ b/packages/@best/agent-hub/src/autoscale-aws/AWSAutoScale.ts
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+*/
+
+import AutoScale, {AutoScaleConfig} from "../autoscale/AutoScale"
+import { StatsManager } from "../StatsManager";
+import AmazonWebServiceAPI, { AWSOptions } from "./AmazonWebServiceAPI";
+
+const THROTTLE_KEY = Object.freeze({
+    SCALE_UP: Symbol(1),
+    SCALE_DOWN: Symbol(3),
+    FETCH_AUTO_SCALING_GROUP: Symbol(3)
+})
+
+// milliseconds
+const SCALE_DOWN_WAIT: number = Number(process.env.SCALE_DOWN_WAIT) || 60000;
+
+// milliseconds
+const THROTTLE_WAIT = 1000;
+
+export default class AWSAutoScale extends AutoScale {
+
+    _awsAPI: AmazonWebServiceAPI;
+    _awsOpts: AWSOptions;
+    _hubStats: any;
+    _scaleDownTimeout?: NodeJS.Timeout;
+    _scalingPolicy?: any;
+    _pendingTasks: Set<Symbol>;
+
+
+    constructor(config: AutoScaleConfig, statsManager: StatsManager) {
+        super(config, statsManager);
+
+        this._awsOpts = config.opts as unknown as AWSOptions;
+        this._pendingTasks = new Set();
+
+        // Check to see if the credential is already set in the environment variable
+        if (!this.checkCredential()) {
+            this.setCredentialFromEnvironmentVariable();
+        }
+
+        this._awsAPI = new AmazonWebServiceAPI(this._awsOpts);
+    }
+
+    checkCredential() {
+        return this._awsOpts.accessKeyId && this._awsOpts.secretAccessKey;
+    }
+
+    setCredentialFromEnvironmentVariable() {
+        if (process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY) {
+            this._awsOpts.accessKeyId = process.env.AWS_ACCESS_KEY_ID;
+            this._awsOpts.secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY
+        } else {
+            throw "AWS Access Key and/or Secret Access Key are not part of the environment variables";
+        }
+    }
+
+    async initialize() {
+        super.initialize();
+
+        await this.fetchAutoScalingGroupStatus();
+    }
+
+    async fetchAutoScalingGroupStatus() {
+        return this._scalingPolicy = await this._awsAPI.getAutoScalingGroup();
+    }
+
+    _scheduledScaleDown() {
+        if (!this._scaleDownTimeout) {
+            this._scaleDownTimeout = setTimeout(() => {
+                this._scaleDown();
+                this._clearScheduledScaleDown();
+            }, SCALE_DOWN_WAIT)
+        }
+    }
+
+    _clearScheduledScaleDown() {
+        if (this._scaleDownTimeout) {
+            console.log("Clearing Scale Down Task");
+            clearTimeout(this._scaleDownTimeout);
+            this._scaleDownTimeout = undefined;
+        }
+    }
+
+    _scaleUp() {
+        this._throttle(THROTTLE_KEY.SCALE_UP, () => {
+            if (this._hubStats) {
+                const currentCapacity = this._scalingPolicy.DesiredCapacity;
+                const desiredCapacity = Math.min(Math.ceil(this._hubStats.new/this._config.scaleThreshold), this._scalingPolicy.MaxSize);
+
+                if (desiredCapacity > currentCapacity) {
+                    this._scaleToDesiredCapacity(desiredCapacity);
+                    console.log(`Scaling up from ${currentCapacity} to ${desiredCapacity} instances`);
+                }
+            } else {
+                console.log("No Hub statistic data");
+            }
+        })
+    }
+
+    _scaleDown() {
+        this._throttle(THROTTLE_KEY.SCALE_DOWN, () => {
+            const currentCapacity = this._scalingPolicy.DesiredCapacity;
+            const desiredCapacity = this._scalingPolicy.MinSize;
+
+            if (desiredCapacity < currentCapacity) {
+                this._scaleToDesiredCapacity(desiredCapacity);
+                console.log(`Scaling down from ${currentCapacity} to ${desiredCapacity} instances`);
+            }
+        })
+    }
+
+    async _scaleToDesiredCapacity(desiredCapacity: number) {
+        if (process.env.DRY_RUN) {
+            console.log("DRY RUN")
+            return;
+        }
+
+        await this._awsAPI.updateAutoScalingGroup({
+            AutoScalingGroupName: this._awsOpts.autoScalingGroupName,
+            DesiredCapacity: desiredCapacity
+        });
+
+        // fetch the autoScalingGroup directly
+        await this.fetchAutoScalingGroupStatus();
+        console.log(`Update ${this._awsOpts.autoScalingGroupName}
+        group ${this._scalingPolicy.DesiredCapacity === desiredCapacity ?
+            'succeeded' : 'failed'}. DesiredCapacity is now set to ${this._scalingPolicy.DesiredCapacity}.`);
+    }
+
+    _throttle(key: Symbol, callback: () => void) {
+        if (!this._pendingTasks.has(key)) {
+            this._pendingTasks.add(key);
+            setTimeout(async () => {
+                await callback();
+                this._pendingTasks.delete(key);
+            }, THROTTLE_WAIT)
+        }
+    }
+
+
+
+    onQueueIncrease(stats: {old: number, new: number, delta: number}) : void {
+        console.log("Queue Increased", stats)
+
+        this._hubStats = stats;
+        // We see increase in load, so cancel scaling down if any.
+        this._clearScheduledScaleDown();
+        this._scaleUp();
+    }
+
+    onQueueDecrease(stats: {old: number, new: number, delta: number}) : void {
+        console.log("Queue Decreased", stats)
+        this._hubStats = stats;
+        if (stats.new === 0) {
+            console.log(`Scheduling to scale down in ${SCALE_DOWN_WAIT/1000} seconds.`);
+            this._scheduledScaleDown();
+
+        } else {
+            if (this._scaleDownTimeout) {
+                console.log("Queue is not empty, delay de-scaling.");
+                this._clearScheduledScaleDown();
+            }
+        }
+    }
+
+    onAgentAdded(stats: {old: number, new: number, delta: number}) : void {
+      console.log("Agent Added", stats)
+
+    }
+
+    onAgentRemoved(stats: {old: number, new: number, delta: number}) : void {
+        console.log("Agent Removed", stats)
+    }
+
+    onAgentAllIdle(stats: {old: number, new: number, delta: number}): void {
+        console.log("Agent All Idle", stats)
+    }
+}

--- a/packages/@best/agent-hub/src/autoscale-aws/AmazonWebServiceAPI.ts
+++ b/packages/@best/agent-hub/src/autoscale-aws/AmazonWebServiceAPI.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+*/
+
+import AWS from 'aws-sdk';
+
+export interface AWSOptions {
+    region: string,
+    autoScalingGroupName: string,
+    accessKeyId: string,
+    secretAccessKey: string
+}
+
+export default class AmazonWebServiceAPI {
+
+    _autoScalingGroupName: string
+    _autoScaling: any;
+    _ec2: any;
+
+    constructor(opt: AWSOptions) {
+
+        AWS.config.update({region: opt.region});
+
+        this._autoScalingGroupName = opt.autoScalingGroupName;
+        this._autoScaling = new AWS.AutoScaling();
+        this._ec2 = new AWS.EC2();
+    }
+
+    async getAutoScalingGroup() {
+        const res = await this._autoScaling.describeAutoScalingGroups({AutoScalingGroupNames: [this._autoScalingGroupName]}).promise();
+        return res.AutoScalingGroups[0];
+    }
+
+    async updateAutoScalingGroup(params: any) {
+        return this._autoScaling.updateAutoScalingGroup(params).promise();
+    }
+
+    async getAgentInstances() {
+        return this._ec2.describeInstances({
+            Filters: [{
+                Name: "tag:aws:autoscaling:groupName",
+                Values: [this._autoScalingGroupName]
+            }]
+        }).promise();
+    }
+
+    async getHubInstance() {
+        return this._ec2.describeInstances({
+            Filters: [{
+                Name: "tag:Name",
+                Values: ["hub"]
+            }]
+        }).promise();
+    }
+}

--- a/packages/@best/agent-hub/src/autoscale/AutoScale.ts
+++ b/packages/@best/agent-hub/src/autoscale/AutoScale.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+*/
+
+
+import { StatsManager } from '../StatsManager'
+import Monitor, { MonitorEvent } from './Monitor';
+
+
+export enum CloudProvider {
+    AWS = "AMAZON_WEB_SERVICE"
+}
+
+export interface AutoScaleConfig {
+    cloudProvider: CloudProvider,
+    scaleThreshold: number,
+    opts?: {[key: string]: any};
+}
+
+export default abstract class AutoScale {
+    abstract onQueueIncrease(stats: {old: number, new: number, delta: number}) : void;
+    abstract onQueueDecrease(stats: {old: number, new: number, delta: number}) : void;
+    abstract onAgentAdded(stats: {old: number, new: number, delta: number}) : void;
+    abstract onAgentRemoved(stats: {old: number, new: number, delta: number}) : void;
+    abstract onAgentAllIdle(stats: {old: number, new: number, delta: number}): void;
+
+    _config: AutoScaleConfig;
+    _statsManager: StatsManager;
+    _monitor?: Monitor;
+
+    constructor(config: AutoScaleConfig, statsManager: StatsManager) {
+        this._config = config;
+        this._statsManager = statsManager;
+    }
+
+    initialize() {
+        this._monitor = new Monitor(this._statsManager);
+        this._monitor.initialize()
+            .on(MonitorEvent.QUEUE_INCREASED, this.onQueueIncrease.bind(this))
+            .on(MonitorEvent.QUEUE_DECREASED, this.onQueueDecrease.bind(this))
+            .on(MonitorEvent.AGENT_ADDED, this.onAgentAdded.bind(this))
+            .on(MonitorEvent.AGENT_REMOVED, this.onAgentRemoved.bind(this))
+            .on(MonitorEvent.AGENT_ALL_IDLE, this.onAgentAllIdle.bind(this));
+    }
+
+    static factory(config: AutoScaleConfig, statsManager: StatsManager) : AutoScale {
+
+        let autoScale: any = null, ctor;
+        switch (config.cloudProvider) {
+            case CloudProvider.AWS:
+                ctor = require('../autoscale-aws/AWSAutoScale').default;
+                console.log(ctor);
+                autoScale = new ctor(config, statsManager);
+                break;
+            default:
+                throw new Error("Invalid Cloud Provider");
+        }
+
+        return autoScale;
+    }
+}

--- a/packages/@best/agent-hub/src/autoscale/Monitor.ts
+++ b/packages/@best/agent-hub/src/autoscale/Monitor.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+*/
+
+import { StatsManager, StatsEvents } from '../StatsManager';
+import { EventEmitter } from 'events';
+
+export enum MonitorEvent {
+    QUEUE_DECREASED = "queue decreased",
+    QUEUE_INCREASED = "queue increased",
+    AGENT_REMOVED = "agent removed",
+    AGENT_ADDED = "agent added",
+    AGENT_ALL_IDLE = "agent all idle",
+}
+
+export default class Monitor extends EventEmitter {
+
+    _statsManager: StatsManager;
+    _prevAgentStats: any;
+    _prevJobStats: any;
+
+    constructor(statsManager: StatsManager) {
+        super();
+        this._statsManager = statsManager;
+    }
+
+    initialize() {
+        this._statsManager.on(StatsEvents.STATS_UPDATE, this._onStatsUpdate.bind(this));
+
+        return this;
+    }
+
+    _onStatsUpdate(stats: any) {
+        console.log("[Statistic]", stats);
+        const hubStats = stats.hub;
+        const agentStats = stats.agentManager;
+
+        this._monitorJobStats(hubStats.pendingJobCount);
+        this._monitorAgentStats(agentStats);
+    }
+
+    _monitorJobStats(jobStats: any) {
+        const delta = this._prevJobStats - jobStats;
+        if (delta === 0) {
+            return;
+        }
+
+        this.emit(delta > 0 ? MonitorEvent.QUEUE_DECREASED : MonitorEvent.QUEUE_INCREASED, {
+            old: this._prevJobStats,
+            new: jobStats,
+            delta: Math.abs(delta)
+        });
+
+        this._prevJobStats = jobStats;
+    }
+
+    _monitorAgentStats(agentStats: any) {
+        if(!agentStats) return;
+
+        console.log(agentStats);
+        if (!this._prevAgentStats) {
+            // initialize our previous data point.
+            this._prevAgentStats = agentStats;
+        }
+
+        const agentCount = agentStats.agents;
+        const agentCountDelta = this._prevAgentStats.agents - agentCount;
+
+        if (agentCountDelta !== 0) {
+            this.emit(agentCountDelta > 0 ? MonitorEvent.AGENT_REMOVED : MonitorEvent.AGENT_ADDED, {
+                old: this._prevAgentStats.agents,
+                new: agentCount,
+                delta: Math.abs(agentCountDelta)
+            });
+        }
+
+        if (agentStats.active === 0) {
+            this.emit(MonitorEvent.AGENT_ALL_IDLE, {
+                old: this._prevAgentStats.active,
+                new: agentStats.active,
+                delta: Math.abs(this._prevAgentStats.active - agentStats.active)
+            })
+        }
+
+        this._prevAgentStats = agentStats;
+    }
+}

--- a/packages/@best/agent-hub/src/cli/index.ts
+++ b/packages/@best/agent-hub/src/cli/index.ts
@@ -30,7 +30,7 @@ function getDefaultConfig(tokenSecret: string, configAsJSON?: string): HubConfig
 
 export function run(config?: HubConfig) {
     const app = express();
-    
+
     const enableHttps = SSL_PFX_FILE && SSL_PFX_PASSPHRASE;
     const http = require(enableHttps ? 'https' : 'http');
 


### PR DESCRIPTION
## Details
**Note: Now that BEST is being rewritten, this PR is outdated and perhaps may be useful for reference consideration if autoscaling is a wanted feature in the future version of BEST.**

This PR extends autoscaling support for AWS. The idea is to monitor the load on the agent-hub to determine when to scale up or down VMs running the best-agent. It is also intended for extensibility to other cloud platforms besides AWS in the future.

The AWS autoscale implementation targets the AutoScalingGroup in AWS for spawning and kill of VMs running best-agent by simply setting the "DesiredCapacity" property in the AutoScalingGroup object through the AWS API.

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No

If yes, please describe the impact and migration path for existing applications:
Please check if your PR fulfills the following requirements:

