### PR TITLE
fix: Fail compilation is bare module specifier is missing

### DIFF
--- a/packages/@best/builder/src/__tests__/best-build.spec.ts
+++ b/packages/@best/builder/src/__tests__/best-build.spec.ts
@@ -175,4 +175,20 @@ describe('buildBenchmark', () => {
         expect(loaded.some(file => file === entry)).toBe(true);
         expect(transformed.some(file => file === entry)).toBe(true);
     });
+
+    test(`throw if bare module specifiers can't be resolved`, async () => {
+        await expect(() => buildBenchmark(
+            path.resolve(__dirname, 'fixtures', 'error-missing-external', 'error-missing-external.js'),
+            {
+                benchmarkOutput: tempDir(),
+                projectName,
+                rootDir
+            },
+            GLOBAL_CONFIG,
+            MOCK_MESSAGER,
+        )).rejects.toHaveProperty(
+            'message',
+            expect.stringMatching(/'x\/missing' is imported by .*, but could not be resolved – treating it as an external dependency/)
+        )
+    });
 });

--- a/packages/@best/builder/src/__tests__/fixtures/error-missing-external/error-missing-external.js
+++ b/packages/@best/builder/src/__tests__/fixtures/error-missing-external/error-missing-external.js
@@ -1,0 +1,1 @@
+import 'x/missing';


### PR DESCRIPTION
## Details

Currently is a bare module specifier is missing when a benchmark is compiled, best reports a warning in the console. This is not ideal since we have to wait until the benchmark runs to realize that the dependency is missing. This PR makes the building fail if a bare module specifier can't be resolved.

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No