### PR TITLE
fix(config): remove check for `.git` in git remote url

### DIFF
--- a/packages/@best/config/src/utils/git.ts
+++ b/packages/@best/config/src/utils/git.ts
@@ -33,7 +33,7 @@ function getBranch(git: SimpleGit.SimpleGit): Promise<string> {
 
 async function getRepository(git: SimpleGit.SimpleGit): Promise<{ owner: string, repo: string }> {
     const url = await git.listRemote(['--get-url']);
-    const matches = url.trim().match(/^.+[:/](.+)\/(.+).git$/);
+    const matches = url.trim().match(/^.+[:/](.+)\/(.+)/);
     if (!matches) {
         throw new Error('Unable to parse git repo');
     }


### PR DESCRIPTION
## Details

This PR addresses #239. The remote url check is too strict, as there are often cases when the `.git` ending is not stored in the git config file. While the current implementation is technically the best, a more loose check would reduce end user friction.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No
