### PR TITLE
fix: check for benchmarkIterations in CLI  args

### DIFF
--- a/packages/@best/config/src/utils/normalize.ts
+++ b/packages/@best/config/src/utils/normalize.ts
@@ -72,7 +72,9 @@ function setCliOptionOverrides(initialOptions: UserConfig, argsCLI: CliConfig): 
                     options.isInteractive = argsCLI[key] !== undefined ? false : undefined;
                     break;
                 case 'iterations':
-                    options.benchmarkIterations = argsCLI[key];
+                    if (argsCLI[key] !== undefined) {
+                        options.benchmarkIterations = argsCLI[key];
+                    }
                     break;
                 case 'runInBatch':
                     options.runInBatch = !!argsCLI[key];


### PR DESCRIPTION
## Details

Adding check if `iterations` is set via the CLI. Fixes #244, and makes sure that in the normalized config `benchmarkIterations` is not `undefined`.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No