### PR TITLE
fix(builder): keep absolute paths

### DIFF
--- a/packages/@best/builder/src/__tests__/best-build.spec.ts
+++ b/packages/@best/builder/src/__tests__/best-build.spec.ts
@@ -73,7 +73,9 @@ describe('buildBenchmark', () => {
 
         expect(benchmarkName).toBe('single-file');
         expect(benchmarkFolder.endsWith(`single-file_${hash}`)).toBe(true);
+        expect(fs.existsSync(benchmarkFolder)).toBe(true);
         expect(benchmarkEntry.endsWith(`single-file_${hash}/artifacts/single-file.html`)).toBe(true);
+        expect(fs.existsSync(benchmarkEntry)).toBe(true);
         expect(typeof benchmarkSignature).toBe('string');
     });
 

--- a/packages/@best/builder/src/build-benchmark.ts
+++ b/packages/@best/builder/src/build-benchmark.ts
@@ -53,7 +53,7 @@ export async function buildBenchmark(entry: string, projectConfig: FrozenProject
     buildLogStream.onBenchmarkBuildStart(entry);
 
     const { gitInfo: { lastCommit: { hash: gitHash }, localChanges } } = globalConfig;
-    const { projectName, benchmarkOutput, rootDir } = projectConfig;
+    const { projectName, benchmarkOutput } = projectConfig;
     const ext = path.extname(entry);
     const benchmarkName = path.basename(entry, ext);
     const benchmarkJSFileName = benchmarkName + ext;
@@ -96,8 +96,8 @@ export async function buildBenchmark(entry: string, projectConfig: FrozenProject
 
     return {
         benchmarkName,
-        benchmarkFolder: path.relative(rootDir, benchmarkFolder),
-        benchmarkEntry: path.relative(rootDir, benchmarkEntry),
+        benchmarkFolder,
+        benchmarkEntry,
         benchmarkSignature,
         projectConfig,
         globalConfig,


### PR DESCRIPTION
## Details
Relative paths do not work later on in Best when the rootDir and the
cwd are not the same because the relative paths are later re-resolved
against the cwd, which points to locations non-existent in the fs

Introduces assertions to existing `build output` test to validate that the output contains usable paths

Fixes #254 

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No
