### PR TITLE
feat(runner-headless): configurable launch options

### DIFF
--- a/docs/content/docs/configuration.md
+++ b/docs/content/docs/configuration.md
@@ -152,12 +152,20 @@ The Best configuration file (`best.config.js`) supports the following options.
 
 `array` The list of runners to run benchmarks.
 
+For the headless runner, [Puppeteer launch options](https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#puppeteerlaunchoptions) can be provided using the `launchOptions` property in the runner config.
+
 ```js
 {
     runners: [
         {
             runner: "@best/runner-headless",
-            alias: "default"
+            alias: "default",
+            config: {
+                launchOptions: {
+                    headless: false,
+                    devtools: true
+                }
+            }
         },
         {
             runner: "@best/runner-remote",

--- a/packages/@best/runner-headless/src/headless.ts
+++ b/packages/@best/runner-headless/src/headless.ts
@@ -24,11 +24,15 @@ const BROWSER_ARGS = [
     '--enable-precise-memory-info',
 ];
 
-const PUPPETEER_OPTIONS = { args: BROWSER_ARGS };
+const PUPPETEER_OPTIONS: puppeteer.LaunchOptions = { args: BROWSER_ARGS };
 
 function tempDir() {
     const TEMP_DIR_PREFIX = 'runner-headless-temp';
     return fs.mkdtempSync(path.join(os.tmpdir(), TEMP_DIR_PREFIX));
+}
+
+interface HeadlessRunnerConfig {
+    readonly launchOptions?: Readonly<puppeteer.LaunchOptions>;
 }
 
 export default class HeadlessBrowser {
@@ -48,7 +52,9 @@ export default class HeadlessBrowser {
     }
 
     async initialize() {
-        this.browser = await puppeteer.launch(PUPPETEER_OPTIONS);
+        const runnerConfig: HeadlessRunnerConfig = this.projectConfig.benchmarkRunnerConfig || {};
+        const { launchOptions = {} } = runnerConfig;
+        this.browser = await puppeteer.launch({ ...PUPPETEER_OPTIONS, ...launchOptions });
         this.page = await this.browser.newPage();
         this.page.on('pageerror', (error: Error) => this.pageError = error);
         await this.page.goto(this.pageUrl);


### PR DESCRIPTION
## Details
Adds the ability to configure launch options for the headless runner for better debugging (of both tests and best itself).

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No
