### PR TITLE
feat(runner-headless): config to serve static assets

### DIFF
--- a/docs/content/docs/configuration.md
+++ b/docs/content/docs/configuration.md
@@ -119,6 +119,25 @@ The Best configuration file (`best.config.js`) supports the following options.
 }
 ```
 
+### `assets`
+
+`array` The list of static asset sources to configure.
+
+If `alias` is not specified the assets are served from `/`.
+
+When `alias` is specified the assets are served from that path, for example `/assets`.
+
+```js
+{
+    assets: [{
+        path: './public/'
+    }, {
+        alias: '/assets',
+        path: '/path/to/node_modules/my-static-assets/dist/'
+    }]
+}
+```
+
 ### `commentThreshold`
 
 `number` For use with the [GitHub Integration](/guide/github-integration), this specifies the threshold for when Best posts a comment about performance on the pull request.

--- a/packages/@best/config/src/index.ts
+++ b/packages/@best/config/src/index.ts
@@ -39,6 +39,7 @@ function generateProjectConfigs(options: NormalizedConfig, isRoot: boolean, gitI
         cache: options.cache,
         cacheDirectory: options.cacheDirectory,
         useHttp: options.useHttp,
+        assets: options.assets,
         moduleDirectories: options.moduleDirectories,
         moduleFileExtensions: options.moduleFileExtensions,
         plugins: options.plugins,

--- a/packages/@best/config/src/utils/defaults.ts
+++ b/packages/@best/config/src/utils/defaults.ts
@@ -21,6 +21,7 @@ const defaultOptions = {
     metrics: ['aggregate', 'script', 'recalculatestyles', 'layout', 'updatelayertree', 'paint', 'compositelayers', 'system', 'idle'] as BenchmarkMetricNames[],
     cacheDirectory: cacheDirectory(),
     useHttp: false,
+    assets: [],
     openPages: false,
     moduleDirectories: ['node_modules'],
     moduleFileExtensions: ['js'],

--- a/packages/@best/runner-abstract/src/__tests__/abstractRunner.spec.ts
+++ b/packages/@best/runner-abstract/src/__tests__/abstractRunner.spec.ts
@@ -1,0 +1,178 @@
+import { existsSync } from 'fs';
+import express from 'express';
+import {
+    BuildConfig,
+    FrozenProjectConfig,
+    FrozenGlobalConfig,
+    RunnerStream,
+    Interruption,
+    BenchmarkResultsSnapshot
+} from '@best/types';
+import AbstractRunner from '..';
+
+interface Server {
+    address: jest.Mock;
+    close: jest.Mock;
+}
+
+interface Express {
+    use: jest.Mock;
+    listen: jest.Mock;
+}
+
+interface TestCache {
+    app?: Express;
+    server?: Server;
+
+    reset: () => void;
+}
+
+jest.mock('express', () => {
+    class MockServer {
+        address = jest.fn(() => ({ port: 28080 }));
+
+        close = jest.fn();
+    }
+
+    class MockExpress {
+        use = jest.fn();
+
+        listen = jest.fn((callback: Function) => {
+            Promise.resolve().then(callback as any);
+            return testCache.server = (testCache.server || new MockServer());
+        });
+    }
+
+    const testCache: {
+        server?: Server,
+        app?: Express,
+        reset: () => void;
+    } = {
+        reset: () => {
+            testCache.server = undefined;
+            testCache.app = undefined;
+        }
+    };
+
+    const express = () => testCache.app = (testCache.app || new MockExpress());
+    express.static = jest.fn(path => path);
+    express.__test__ = testCache;
+    return express;
+});
+
+jest.mock('fs', () => {
+    const fs = jest.requireActual('fs');
+    return {
+        ...fs,
+        existsSync: jest.fn(fs.existsSync)
+    };
+});
+
+class TestRunner extends AbstractRunner {
+    run = jest.fn(
+        async (
+            benchmarkBuilds: BuildConfig[],
+            projectConfig: FrozenProjectConfig,
+            globalConfig: FrozenGlobalConfig,
+            runnerLogStream: RunnerStream,
+            interruption?: Interruption
+        ): Promise<BenchmarkResultsSnapshot[]> => {
+            for (const benchmarkInfo of benchmarkBuilds) {
+                const { benchmarkEntry, benchmarkRemoteEntry } = benchmarkInfo;
+                await this.initializeServer(benchmarkRemoteEntry || benchmarkEntry, projectConfig);
+            }
+
+            return [];
+        }
+    );
+}
+
+const { __test__ }: { __test__: TestCache } = (express as any);
+
+beforeEach(() => __test__.reset());
+
+describe('AbstractRunner', () => {
+    describe('initializeServer()', () => {
+        const benchmarkEntry = 'testFolder/testEntry';
+        const assetPath = 'some/asset/path';
+
+        let runner: TestRunner;
+
+        beforeEach(() => {
+            runner = new TestRunner();
+            (existsSync as jest.Mock).mockImplementation(jest.requireActual('fs').existsSync);
+        });
+
+        it('returns a file: URI if not using http', async () => {
+            const projectConfig: FrozenProjectConfig = <FrozenProjectConfig><Partial<FrozenProjectConfig>>{
+                projectName: 'test',
+                useHttp: false
+            };
+            const result = await runner.initializeServer(benchmarkEntry, projectConfig);
+            expect(result).toStrictEqual({ terminate: expect.any(Function), url: `file://${benchmarkEntry}` });
+        });
+
+        it('returns a http: URI when using http', async () => {
+            const projectConfig: FrozenProjectConfig = <FrozenProjectConfig><Partial<FrozenProjectConfig>>{
+                projectName: 'test',
+                useHttp: true
+            };
+
+            const result = await runner.initializeServer(benchmarkEntry, projectConfig);
+            expect(result).toStrictEqual({ terminate: expect.any(Function), url: `http://127.0.0.1:28080/testEntry` });
+        });
+
+        it('serves assets', async () => {
+            const projectConfig: FrozenProjectConfig = <FrozenProjectConfig><Partial<FrozenProjectConfig>>{
+                projectName: 'test',
+                useHttp: true,
+                assets: [{ path: assetPath }]
+            };
+
+            (existsSync as jest.Mock).mockReturnValue(true);
+            const result = await runner.initializeServer(benchmarkEntry, projectConfig);
+            expect(__test__.app.use).toHaveBeenNthCalledWith(1, 'testFolder');
+            expect(__test__.app.use).toHaveBeenNthCalledWith(2, assetPath);
+            expect(result).toStrictEqual({ terminate: expect.any(Function), url: `http://127.0.0.1:28080/testEntry` });
+        });
+
+        it('serves aliased assets', async () => {
+            const projectConfig: FrozenProjectConfig = <FrozenProjectConfig><Partial<FrozenProjectConfig>>{
+                projectName: 'test',
+                useHttp: true,
+                assets: [{ alias: 'testAlias', path: assetPath }]
+            };
+
+            (existsSync as jest.Mock).mockReturnValue(true);
+            const result = await runner.initializeServer(benchmarkEntry, projectConfig);
+            expect(__test__.app.use).toHaveBeenNthCalledWith(1, 'testFolder');
+            expect(__test__.app.use).toHaveBeenNthCalledWith(2, '/testAlias', assetPath);
+            expect(result).toStrictEqual({ terminate: expect.any(Function), url: `http://127.0.0.1:28080/testEntry` });
+        });
+
+        it('throws an error for invalid asset paths', async () => {
+            const projectConfig: FrozenProjectConfig = <FrozenProjectConfig><Partial<FrozenProjectConfig>>{
+                projectName: 'test',
+                useHttp: true,
+                assets: [{}]
+            };
+
+            expect(
+                () => runner.initializeServer(benchmarkEntry, projectConfig)
+            ).rejects.toThrowError(`Invalid asset path: '${undefined}'`);
+        });
+
+        it('throws an error for missing asset paths', async () => {
+            const path = '/path/does/not/exist';
+            const projectConfig: FrozenProjectConfig = <FrozenProjectConfig><Partial<FrozenProjectConfig>>{
+                projectName: 'test',
+                useHttp: true,
+                assets: [{ path }]
+            };
+
+            expect(
+                () => runner.initializeServer(benchmarkEntry, projectConfig)
+            ).rejects.toThrowError(`Invalid asset path: '${path}'`);
+        });
+    });
+});

--- a/packages/@best/runner-headless/src/index.ts
+++ b/packages/@best/runner-headless/src/index.ts
@@ -19,10 +19,9 @@ export default class Runner extends AbstractRunner {
         const snapshotResults: BenchmarkResultsSnapshot[] = [];
         for (const benchmarkInfo of benchmarkBuilds) {
             const { benchmarkEntry, benchmarkRemoteEntry, benchmarkSignature } = benchmarkInfo;
-            const { useHttp } = projectConfig;
             const runtimeOptions = this.getRuntimeOptions(projectConfig);
             const state = this.initializeBenchmarkState();
-            const { url, terminate } = await this.initializeServer(benchmarkRemoteEntry || benchmarkEntry, useHttp);
+            const { url, terminate } = await this.initializeServer(benchmarkRemoteEntry || benchmarkEntry, projectConfig);
             const browser = new HeadlessBrowser(url, projectConfig);
 
             try {

--- a/packages/@best/types/src/config.ts
+++ b/packages/@best/types/src/config.ts
@@ -105,6 +105,7 @@ export interface NormalizedConfig {
     gitIntegration: boolean,
     generateHTML: boolean,
     useHttp: boolean,
+    assets: AssetConfig[],
     externalStorage?: string,
     apiDatabase: ApiDatabaseConfig,
     commentThreshold: number,
@@ -153,7 +154,13 @@ export interface GlobalConfig {
 
 export type ProjectConfigPlugin = string | [string, { [key : string]: any }]
 
+export type AssetConfig = {
+    alias?: string;
+    path: string;
+}
+
 export interface ProjectConfig {
+    assets: AssetConfig[];
     useHttp: boolean;
     benchmarkRunner: string;
     benchmarkEnvironment: any;

--- a/scripts/jest/root.config.js
+++ b/scripts/jest/root.config.js
@@ -20,6 +20,7 @@ module.exports = {
         '<rootDir>/packages/@best/agent-frontend',
         '<rootDir>/packages/@best/config',
         '<rootDir>/packages/@best/builder',
+        '<rootDir>/packages/@best/runner-abstract',
         '<rootDir>/packages/@best/runner-headless',
         '<rootDir>/packages/@best/cli',
     ]


### PR DESCRIPTION
## Details
Adds the ability to configure serving static assets for access from performance tests, such as style sheets.

This is used in particular to enable running performance testing for LWC components with style-accurate painting with statically served SLDS assets.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No
