### PR TITLE
feat(api-db): configure fetching temporary results

### DIFF
--- a/docs/content/docs/configuration.md
+++ b/docs/content/docs/configuration.md
@@ -119,6 +119,21 @@ The Best configuration file (`best.config.js`) supports the following options.
 }
 ```
 
+With `filtering.allowTemporary` set to true, the SQL database adapters (both Postgres and SQLite) will include temporary results in the snapshots available via the frontend API.
+
+```js
+{
+    apiDatabase: {
+        adapter: 'sql/postgres',
+        uri: `postgresql://localhost`,
+        ssl: false,
+        filtering: {
+            allowTemporary: true
+        }
+    }
+}
+```
+
 ### `commentThreshold`
 
 `number` For use with the [GitHub Integration](/guide/github-integration), this specifies the threshold for when Best posts a comment about performance on the pull request.

--- a/packages/@best/api-db/jest.config.js
+++ b/packages/@best/api-db/jest.config.js
@@ -1,0 +1,6 @@
+const COMMON = require('../../../scripts/jest/common.config');
+
+module.exports = {
+    ...COMMON,
+    displayName: 'api-db'
+}

--- a/packages/@best/api-db/src/sql/__tests__/db.spec.ts
+++ b/packages/@best/api-db/src/sql/__tests__/db.spec.ts
@@ -1,0 +1,95 @@
+import { ApiDatabaseConfig } from '@best/types';
+import { SQLDatabase, SQLQueryResult } from '../db';
+
+class TestDatabase extends SQLDatabase {
+    constructor(config: ApiDatabaseConfig) {
+        super(config);
+    }
+
+    query = jest.fn((text: string, params: any[]): Promise<SQLQueryResult> => {
+        return Promise.resolve({
+            rows: [{ text, params }]
+        });
+    });
+}
+
+const testConfigBasic: ApiDatabaseConfig = {
+    adapter: 'sql/postgres',
+    uri: 'postgresql://localhost',
+    ssl: false,
+};
+
+const testConfigExcludeTemporary: ApiDatabaseConfig = {
+    ...testConfigBasic,
+    filtering: {
+        allowTemporary: false
+    }
+};
+
+const testConfigIncludeTemporary: ApiDatabaseConfig = {
+    ...testConfigBasic,
+    filtering: {
+        allowTemporary: true
+    }
+};
+
+describe('SQLDatabase', () => {
+    describe('fetchSnapshots()', () => {
+        it('excludes temporary results with basic db config', async () => {
+            const database = new TestDatabase(testConfigBasic);
+            await database.fetchSnapshots(1, undefined);
+            expect(database.query).toHaveBeenCalledWith(
+                `SELECT * FROM snapshots WHERE "project_id" = $1 AND "temporary" = '0' ORDER BY commit_date, name`,
+                [1]
+            );
+        });
+
+        it('excludes temporary results with basic db config with since', async () => {
+            const database = new TestDatabase(testConfigBasic);
+            const date = new Date();
+            await database.fetchSnapshots(1, date);
+            expect(database.query).toHaveBeenCalledWith(
+                `SELECT * FROM snapshots WHERE "project_id" = $1 AND "temporary" = '0' AND "commit_date" > $2 ORDER BY commit_date, name`,
+                [1, date]
+            );
+        });
+
+        it('excludes temporary results with explicit exclusion', async () => {
+            const database = new TestDatabase(testConfigExcludeTemporary);
+            await database.fetchSnapshots(1, undefined);
+            expect(database.query).toHaveBeenCalledWith(
+                `SELECT * FROM snapshots WHERE "project_id" = $1 AND "temporary" = '0' ORDER BY commit_date, name`,
+                [1]
+            );
+        });
+
+        it('excludes temporary results with explicit exclusion with since', async () => {
+            const database = new TestDatabase(testConfigExcludeTemporary);
+            const date = new Date();
+            await database.fetchSnapshots(1, date);
+            expect(database.query).toHaveBeenCalledWith(
+                `SELECT * FROM snapshots WHERE "project_id" = $1 AND "temporary" = '0' AND "commit_date" > $2 ORDER BY commit_date, name`,
+                [1, date]
+            );
+        });
+
+        it('includes temporary results with explicit inclusion', async () => {
+            const database = new TestDatabase(testConfigIncludeTemporary);
+            await database.fetchSnapshots(1, undefined);
+            expect(database.query).toHaveBeenCalledWith(
+                `SELECT * FROM snapshots WHERE "project_id" = $1  ORDER BY commit_date, name`,
+                [1]
+            );
+        });
+
+        it('includes temporary results with explicit inclusion with since', async () => {
+            const database = new TestDatabase(testConfigIncludeTemporary);
+            const date = new Date();
+            await database.fetchSnapshots(1, date);
+            expect(database.query).toHaveBeenCalledWith(
+                `SELECT * FROM snapshots WHERE "project_id" = $1  AND "commit_date" > $2 ORDER BY commit_date, name`,
+                [1, date]
+            );
+        });
+    });
+});

--- a/packages/@best/api-db/src/sql/postgres/db.ts
+++ b/packages/@best/api-db/src/sql/postgres/db.ts
@@ -17,7 +17,7 @@ export default class PostgresDatabase extends SQLDatabase {
     migrated = false;
 
     constructor(config: ApiDatabaseConfig) {
-        super();
+        super(config);
         this.pool = new Pool({
             connectionString: config.uri,
             ssl: config.ssl || PGSSLMODE ? { rejectUnauthorized: false } : false

--- a/packages/@best/api-db/src/sql/sqlite/db.ts
+++ b/packages/@best/api-db/src/sql/sqlite/db.ts
@@ -15,7 +15,7 @@ export default class SQLiteDatabase extends SQLDatabase {
     migrated = false;
 
     constructor(config: ApiDatabaseConfig) {
-        super()
+        super(config);
         this.dbPromise = sqlite.open(config.uri, { verbose: true })
     }
 

--- a/packages/@best/frontend/src/modules/store/transformer/transformer.js
+++ b/packages/@best/frontend/src/modules/store/transformer/transformer.js
@@ -44,6 +44,7 @@ const normalizeBenchmark = (benchmark) => {
 }
 
 export const snapshotsToBenchmarks = (snapshots) => {
+    snapshots.sort((a, b) => a.id - b.id);
     const benchesByKeys = snapshots.reduce((acc, snap) => ({
         ...acc,
         [snap.name]: {
@@ -52,6 +53,7 @@ export const snapshotsToBenchmarks = (snapshots) => {
             commitDates: [...accumulateProperty(snap, acc[snap.name], 'commitDate')],
             environmentHashes: [...accumulateProperty(snap, acc[snap.name], 'environmentHash', 'environmentHashes')],
             similarityHashes: [...accumulateProperty(snap, acc[snap.name], 'similarityHash', 'similarityHashes')],
+            isTemporary: [...accumulateProperty(snap, acc[snap.name], 'temporary', 'isTemporary')],
             metrics: mergeMetrics(snap, acc[snap.name])
         }
     }), {})

--- a/packages/@best/types/src/config.ts
+++ b/packages/@best/types/src/config.ts
@@ -61,10 +61,15 @@ export interface Interruption {
     requestInterruption() :void;
 }
 
+export interface ApiDatabaseFilteringConfig {
+    allowTemporary?: boolean;
+}
+
 export interface ApiDatabaseConfig {
     adapter: string;
     uri: string;
     ssl?: any;
+    filtering?: ApiDatabaseFilteringConfig;
 }
 
 export interface FrontendConfig {

--- a/scripts/jest/root.config.js
+++ b/scripts/jest/root.config.js
@@ -11,16 +11,17 @@ module.exports = {
     },
 
     projects: [
-        '<rootDir>/packages/@best/console-stream',
-        '<rootDir>/packages/@best/github-integration',
-        '<rootDir>/packages/@best/utils',
-        '<rootDir>/packages/@best/regex-util',
-        '<rootDir>/packages/@best/frontend',
         '<rootDir>/packages/@best/agent',
         '<rootDir>/packages/@best/agent-frontend',
-        '<rootDir>/packages/@best/config',
+        '<rootDir>/packages/@best/api-db',
         '<rootDir>/packages/@best/builder',
-        '<rootDir>/packages/@best/runner-headless',
         '<rootDir>/packages/@best/cli',
+        '<rootDir>/packages/@best/config',
+        '<rootDir>/packages/@best/console-stream',
+        '<rootDir>/packages/@best/frontend',
+        '<rootDir>/packages/@best/github-integration',
+        '<rootDir>/packages/@best/regex-util',
+        '<rootDir>/packages/@best/runner-headless',
+        '<rootDir>/packages/@best/utils',
     ]
 };


### PR DESCRIPTION
## Details
- Adds configuration to allow the DB API to return temporary results
- Changes frontend to allow for sorting snapshots by ID, and adding suffixes for duplicate commits
  (temporary snapshots can have the same IDs)
  - the suffixes are 0-indexed per unique commit, and only shown on temporary snapshots

![image](https://user-images.githubusercontent.com/43354087/99586990-734aca00-29b6-11eb-87d5-3c81ed98e9c7.png)

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No
