### PR TITLE
feat(config): configurable main branch

### DIFF
--- a/docs/content/docs/configuration.md
+++ b/docs/content/docs/configuration.md
@@ -98,6 +98,12 @@ The Best configuration file (`best.config.js`) supports the following options.
 
 `string` Specifies the name of the benchmarking project.
 
+### `mainBranch`
+
+`string` Specifies the name of the main branch, defaults to `master`.
+
+When best is not run on the main branch the snapshot is marked as temporary.
+
 ### `externalStorage`
 
 `string` Allows saving the results in an arbitrary storage system. Specify the external storage adapter to use. Currently Best supports AWS with the `@best/store-aws` adapter.

--- a/packages/@best/api-db/src/store.ts
+++ b/packages/@best/api-db/src/store.ts
@@ -83,8 +83,8 @@ export const saveBenchmarkSummaryInDB = async (benchmarkResults: BenchmarkResult
                 commit: lastCommit.hash,
                 commitDate: lastCommit.date,
                 environmentHash,
-                temporary: branch !== 'master'
-            }
+                temporary: branch !== globalConfig.mainBranch
+            };
 
             if (stats) {
                 const snapshots = generateSnapshots(runSettings, stats.results);

--- a/packages/@best/config/src/__tests__/best-config.spec.ts
+++ b/packages/@best/config/src/__tests__/best-config.spec.ts
@@ -9,6 +9,7 @@ import path from 'path';
 import { readConfig } from '../index';
 
 const CONFIG_FIXTURE = path.resolve(__dirname, 'fixtures', 'best_config_js');
+const CONFIG_FIXTURE_OVERRIDES = path.resolve(__dirname, 'fixtures', 'best_config_overrides_js');
 
 describe('config file resolution', () => {
     test('throw if not config is found in the directory', async () => {
@@ -48,5 +49,17 @@ describe('config normalization', () => {
         const iterations = 100;
         const config = await readConfig({ iterations }, CONFIG_FIXTURE);
         expect(config.projectConfig.benchmarkIterations).toBe(iterations);
+    });
+
+    describe('mainBranch', () => {
+        test('has the expected fallback', async () => {
+            const config = await readConfig({}, CONFIG_FIXTURE);
+            expect(config.globalConfig.mainBranch).toBe('master');
+        });
+
+        test('can be configured', async () => {
+            const config = await readConfig({}, CONFIG_FIXTURE_OVERRIDES);
+            expect(config.globalConfig.mainBranch).toBe('test-branch');
+        });
     });
 });

--- a/packages/@best/config/src/__tests__/fixtures/best_config_overrides_js/best.config.js
+++ b/packages/@best/config/src/__tests__/fixtures/best_config_overrides_js/best.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+    projectName: 'test',
+    mainBranch: 'test-branch'
+};

--- a/packages/@best/config/src/index.ts
+++ b/packages/@best/config/src/index.ts
@@ -20,6 +20,7 @@ function generateProjectConfigs(options: NormalizedConfig, isRoot: boolean, gitI
 
         globalConfig = Object.freeze({
             gitIntegration: options.gitIntegration,
+            mainBranch: options.mainBranch,
             generateHTML: options.generateHTML,
             compareStats: options.compareStats,
             externalStorage: options.externalStorage,

--- a/packages/@best/config/src/utils/defaults.ts
+++ b/packages/@best/config/src/utils/defaults.ts
@@ -11,6 +11,7 @@ import { BenchmarkMetricNames } from '@best/types';
 const defaultOptions = {
     cache: true,
     gitIntegration: false,
+    mainBranch: 'master',
     commentThreshold: 5,
     specs: undefined,
     generateHTML: false,

--- a/packages/@best/types/src/config.ts
+++ b/packages/@best/types/src/config.ts
@@ -112,6 +112,7 @@ export interface NormalizedConfig {
     isInteractive?: boolean,
     runInBatch?: boolean;
     openPages: boolean,
+    mainBranch: string;
     moduleDirectories: string[],
     moduleFileExtensions: string[],
     moduleNameMapper: { [moduleName:string]: string },
@@ -140,6 +141,7 @@ export interface NormalizedConfig {
 export interface GlobalConfig {
     gitIntegration: boolean;
     projects: string[];
+    mainBranch: string;
     rootDir: string;
     runInBand: boolean;
     compareStats?: string[];


### PR DESCRIPTION
## Details
Enables the main branch name to be configurable so snapshots from branches other than `master` can be non-temporary.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

Note: I made `master` the default branch for seamless backwards compatibility, but we may eventually want to forgo that since the [default branch on Github has changed from `master` to `main`](https://github.com/github/renaming). Thoughts on doing that now?

Another slightly more seamless transition might be to have `mainBranch` be nullable, and if undefined it accepts both `master` and `main` as non-temporary branches in `store.ts#L86` (more complicated, but supports both):

```js
    temporary: globalConfig.mainBranch
        ? (globalConfig.mainBranch !== branch)
        : ('master' !== branch && 'main' !== branch)
```