### PR TITLE
 feature: Add cookie consent banner functionality to bestjs

### DIFF
--- a/docs/src/client/assets/css/cookie-consent.css
+++ b/docs/src/client/assets/css/cookie-consent.css
@@ -1,0 +1,643 @@
+#onetrust-consent-sdk div#optanon-popup-bg {
+    background: #fff;
+    opacity: 0.75;
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk {
+    margin-top: 0 !important;
+    width: 1008px;
+    max-width: 1008px;
+    height: 549px;
+    position: fixed;
+    top: 50px !important;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    margin: auto;
+    -webkit-box-shadow: 0 5px 7px rgba(0, 0, 0, 0.3);
+    -moz-box-shadow: 0 5px 7px rgba(0, 0, 0, 0.3);
+    box-shadow: 0 5px 7px rgba(0, 0, 0, 0.3);
+    background-color: #f4f4f4;
+}
+@media (max-width: 1023px) {
+    #onetrust-consent-sdk div#onetrust-pc-sdk {
+        width: auto;
+        height: auto;
+        max-height: 95vh;
+        margin-left: 10px;
+        margin-right: 10px;
+        top: 10px !important;
+        overflow: scroll;
+        bottom: unset;
+    }
+}
+@media (max-width: 1023px) {
+    #onetrust-consent-sdk div#onetrust-pc-sdk {
+        overflow-y: scroll;
+        overflow-x: hidden;
+    }
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk #optanon-popup-bg {
+    background: #fff;
+    opacity: 0.75;
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-pc-header {
+    height: 137px;
+    border-bottom: 0;
+    padding: 0;
+    display: inline-block;
+    width: 100%;
+    vertical-align: middle;
+}
+@media (max-width: 1023px) {
+    #onetrust-consent-sdk div#onetrust-pc-sdk .ot-pc-header {
+        background-color: #f3f3f3;
+        height: 83px;
+    }
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-pc-header .ot-pc-logo-container {
+    margin-left: 0;
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-pc-header .ot-pc-logo {
+    height: 60px;
+    width: 180px;
+    background-position: center !important;
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 35px;
+    display: block;
+}
+@media (max-width: 1023px) {
+    #onetrust-consent-sdk div#onetrust-pc-sdk .ot-pc-header .ot-pc-logo {
+        margin-top: 15px !important;
+    }
+}
+@media (max-width: 425px), (max-height: 425px) and (max-width: 896px) and (orientation: landscape) {
+    #onetrust-consent-sdk div#onetrust-pc-sdk .ot-pc-header .ot-pc-logo {
+        width: 150px !important;
+        height: 40px !important;
+    }
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-pc-header #ot-pc-title {
+    font-family: 'SalesforceSansLight', Helvetica, Arial, sans-serif;
+    font-size: 42px !important;
+    font-weight: 100;
+    color: #222;
+    top: 27px;
+    left: 130px;
+    position: absolute;
+}
+@media (max-width: 1023px) {
+    #onetrust-consent-sdk div#onetrust-pc-sdk .ot-pc-header #ot-pc-title {
+        top: 20px !important;
+        font-size: 21px !important;
+        margin-left: 10px !important;
+        margin-top: 10px !important;
+        padding: 0;
+    }
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-pc-header .ot-title-cntr {
+    position: static;
+    display: block;
+    width: 100%;
+    padding-left: 10px;
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-pc-header .ot-title-cntr #ot-pc-title {
+    float: left;
+    margin-left: 30px;
+    margin-top: 15px;
+    top: 30px;
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-pc-header .ot-title-cntr #ot-pc-title::before,
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-pc-header .ot-title-cntr #ot-pc-title::after {
+    content: none;
+    background-color: #f4f4f4;
+    height: 0;
+    width: 0;
+    position: static;
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-enbl-chr.ot-hosts-ui#ot-pc-lst .ot-lst-cntr {
+    height: 96%;
+    background-color: #fff;
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk #ot-pc-content {
+    height: calc(-96%);
+    margin-left: 0;
+    margin: 0 10px 0 0;
+}
+@media (max-width: 1023px) {
+    #onetrust-consent-sdk div#onetrust-pc-sdk #ot-pc-content {
+        margin: 0;
+        height: auto !important;
+        min-height: 380px;
+    }
+}
+@media (max-width: 1024px) {
+    #onetrust-consent-sdk div#onetrust-pc-sdk #ot-pc-content {
+        height: auto !important;
+        min-height: 300px;
+    }
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk #ot-pc-content .ot-grps-cntr {
+    height: 100%;
+    position: relative;
+    max-width: 100%;
+    margin: 0 auto;
+    padding: 0;
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-sdk-columns.ot-tab-list {
+    overflow: hidden;
+    padding-left: 2%;
+}
+@media (max-width: 1023px) {
+    #onetrust-consent-sdk div#onetrust-pc-sdk .ot-sdk-columns.ot-tab-list {
+        padding: 0;
+    }
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-sdk-columns.ot-tab-list ul.ot-cat-grp {
+    float: left;
+    display: initial;
+    width: 100%;
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-sdk-columns.ot-tab-list ul.ot-cat-grp li {
+    margin: 0;
+    min-height: 45px;
+    width: 100%;
+}
+#onetrust-consent-sdk
+    div#onetrust-pc-sdk
+    .ot-sdk-columns.ot-tab-list
+    ul.ot-cat-grp
+    li
+    .category-menu-switch-handler {
+    padding: 12px;
+    border-left: 4px solid transparent;
+    border-bottom: 0;
+}
+#onetrust-consent-sdk
+    div#onetrust-pc-sdk
+    .ot-sdk-columns.ot-tab-list
+    ul.ot-cat-grp
+    li
+    .category-menu-switch-handler
+    h3 {
+    font-family: 'SalesforceSansRegular', Helvetica, Arial, sans-serif;
+    font-size: 15px !important;
+    line-height: 21px !important;
+    color: #0b5cab;
+    font-weight: normal;
+}
+#onetrust-consent-sdk
+    div#onetrust-pc-sdk
+    .ot-sdk-columns.ot-tab-list
+    ul.ot-cat-grp
+    li
+    .category-menu-switch-handler.ot-active-menu {
+    border-left: 4px solid #00a1e0;
+    background-color: #fff;
+}
+#onetrust-consent-sdk
+    div#onetrust-pc-sdk
+    .ot-sdk-columns.ot-tab-list
+    ul.ot-cat-grp
+    li
+    .category-menu-switch-handler.ot-active-menu
+    h3 {
+    color: #000;
+    font-family: 'SalesforceSansBold', Helvetica, Arial, sans-serif;
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-tab-desc {
+    height: auto;
+    min-height: 340px;
+    background-color: #fff;
+    padding: 1%;
+    margin-left: 0;
+    width: 69%;
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-tab-desc #ot-pvcy-hdr,
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-tab-desc .ot-cat-header {
+    font-family: 'SalesforceSansBold', Helvetica, Arial, sans-serif;
+    font-size: 22px !important;
+    line-height: 2.36 !important;
+    color: #032e61;
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-tab-desc .ot-grp-desc {
+    font-family: 'SalesforceSansRegular', Helvetica, Arial, sans-serif;
+    font-size: 15px;
+    line-height: 1.6;
+    color: #222;
+    word-break: normal !important;
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-tab-desc .ot-desc-cntr {
+    margin-top: 0;
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-tab-desc .ot-desc-cntr .ot-grp-hdr1 {
+    padding-top: 0;
+}
+@media (max-width: 1023px) {
+    #onetrust-consent-sdk div#onetrust-pc-sdk .ot-tab-desc,
+    #onetrust-consent-sdk div#onetrust-pc-sdk #ot-tab-desc,
+    #onetrust-consent-sdk div#onetrust-pc-sdk .ot-desc-cntr {
+        padding: 0;
+        margin: 0;
+        min-height: auto;
+        background-color: #fff;
+    }
+}
+@media (max-width: 1023px) {
+    #onetrust-consent-sdk div#onetrust-pc-sdk .ot-tab-desc #ot-pvcy-hdr,
+    #onetrust-consent-sdk div#onetrust-pc-sdk #ot-tab-desc #ot-pvcy-hdr,
+    #onetrust-consent-sdk div#onetrust-pc-sdk .ot-desc-cntr #ot-pvcy-hdr,
+    #onetrust-consent-sdk div#onetrust-pc-sdk .ot-tab-desc .ot-cat-header,
+    #onetrust-consent-sdk div#onetrust-pc-sdk #ot-tab-desc .ot-cat-header,
+    #onetrust-consent-sdk div#onetrust-pc-sdk .ot-desc-cntr .ot-cat-header,
+    #onetrust-consent-sdk div#onetrust-pc-sdk .ot-tab-desc .category-menu-switch-handler h3,
+    #onetrust-consent-sdk div#onetrust-pc-sdk #ot-tab-desc .category-menu-switch-handler h3,
+    #onetrust-consent-sdk div#onetrust-pc-sdk .ot-desc-cntr .category-menu-switch-handler h3 {
+        padding: 10px 0 5px 10px;
+        font-family: 'SalesforceSansBold', Helvetica, Arial, sans-serif;
+        font-size: 22px !important;
+        line-height: 2.36 !important;
+        color: #032e61;
+    }
+}
+@media (max-width: 1023px) {
+    #onetrust-consent-sdk div#onetrust-pc-sdk .ot-tab-desc .ot-grp-desc,
+    #onetrust-consent-sdk div#onetrust-pc-sdk #ot-tab-desc .ot-grp-desc,
+    #onetrust-consent-sdk div#onetrust-pc-sdk .ot-desc-cntr .ot-grp-desc {
+        padding: 5px 20px 20px 20px;
+        font-family: 'SalesforceSansRegular', Helvetica, Arial, sans-serif;
+        font-size: 15px;
+        line-height: 1.6;
+        color: #222;
+        word-break: normal !important;
+    }
+}
+@media (max-width: 1023px) {
+    #onetrust-consent-sdk div#onetrust-pc-sdk .ot-tab-desc .ot-hlst-cntr,
+    #onetrust-consent-sdk div#onetrust-pc-sdk #ot-tab-desc .ot-hlst-cntr,
+    #onetrust-consent-sdk div#onetrust-pc-sdk .ot-desc-cntr .ot-hlst-cntr {
+        padding: 0 0 30px 20px;
+        margin: 0 0 20px 0;
+    }
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-always-active {
+    font-size: 16px;
+    line-height: 1.3;
+    color: #1a73e8;
+    font-weight: normal;
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .category-host-list-handler {
+    font-size: 12.8px;
+    line-height: 14.08px;
+    color: #1a73e8;
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-tgl {
+    padding-right: 0;
+}
+@media (max-width: 1023px) {
+    #onetrust-consent-sdk div#onetrust-pc-sdk .ot-tgl {
+        margin: 20px 20px 0 0;
+    }
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-tgl .ot-switch {
+    position: relative;
+    display: inline-block;
+    width: 37px;
+    height: 24px;
+    margin-bottom: 0;
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-tgl .ot-switch .ot-switch-nob {
+    background-color: #c1b9b4;
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-tgl .ot-switch .ot-switch-nob::before {
+    position: absolute;
+    content: '';
+    height: 20px;
+    width: 20px;
+    -webkit-transition: 0.4s;
+    border-radius: 100%;
+    top: 2px;
+    transition: 0.4s;
+    left: 2px;
+    background-color: #fff;
+}
+#onetrust-consent-sdk
+    div#onetrust-pc-sdk
+    .ot-tgl
+    input:checked
+    + .ot-switch
+    .ot-switch-nob::before {
+    -webkit-transform: translateX(13px);
+    -ms-transform: translateX(13px);
+    transform: translateX(13px);
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-tgl input:checked + .ot-switch .ot-switch-nob {
+    background-color: #0b5cab;
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-lst-subhdr #ot-search-cntr {
+    background-color: transparent;
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-lst-subhdr #vendor-search-handler {
+    font-size: 12.8px;
+}
+@media (min-width: 640px) {
+    #onetrust-consent-sdk div#onetrust-pc-sdk #ot-lst-cnt {
+        width: calc(100% - 183px);
+        padding-left: 80px;
+        padding-right: 100px;
+        padding-top: 20px;
+    }
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-host-opts {
+    padding-right: 15px;
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk #ot-pc-lst {
+    height: calc(100% - 194px) !important;
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk #ot-pc-lst #ot-lst-title span {
+    color: #0b5cab;
+    font-size: 14.4px;
+    text-transform: uppercase;
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk #ot-pc-lst .ot-host-name {
+    font-size: 12.8px !important;
+    line-height: 1.2 !important;
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk #ot-pc-lst .ot-host-desc {
+    font-size: 11.04px !important;
+    line-height: 1.4 !important;
+    color: #696969 !important;
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk #ot-pc-lst .ot-host-expand {
+    font-size: 11.2px;
+    color: #696969 !important;
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-host-item .ot-host-opt li > div div {
+    font-size: 12.8px;
+    color: #6e8290;
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-chkbox input:checked ~ label::before {
+    background-color: #4285f4;
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-chkbox label::before {
+    height: 18px;
+    width: 18px;
+    border: 1px solid #1a73e8;
+    left: 0;
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk button#clear-filters-handler {
+    font-size: 14.4px;
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-fltr-opt span {
+    font-size: 12.8px;
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-fltr-btns button {
+    font-size: 12.8px;
+    border-radius: 2px;
+    background-color: #215ca0;
+    border-color: #215ca0;
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-pc-footer {
+    padding: 0 30px 20px;
+    border-top: 0;
+    position: static;
+    height: 34px;
+    width: auto;
+    float: none;
+}
+@media (max-width: 640px) {
+    #onetrust-consent-sdk div#onetrust-pc-sdk .ot-pc-footer {
+        height: auto;
+    }
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-pc-footer .ot-pc-footer-logo {
+    display: none;
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-pc-footer .ot-btn-container {
+    float: right;
+    text-align: center;
+}
+@media (max-width: 640px) {
+    #onetrust-consent-sdk div#onetrust-pc-sdk .ot-pc-footer .ot-btn-container {
+        float: none;
+    }
+}
+#onetrust-consent-sdk div#onetrust-pc-sdk .ot-pc-footer .ot-btn-container .ot-btn-subcntr {
+    max-width: 100%;
+}
+#onetrust-consent-sdk
+    div#onetrust-pc-sdk
+    .ot-pc-footer
+    .ot-btn-container
+    button.save-preference-btn-handler.onetrust-close-btn-handler {
+    visibility: hidden;
+    padding: 0;
+    border: 0;
+    margin: 0;
+    height: 47px;
+    min-width: 155px;
+    border-radius: 4px;
+    margin-left: 15px;
+    margin-right: 15px;
+    background-color: #0b5cab !important;
+    color: #fff !important;
+    border-color: #0b5cab !important;
+    padding: 14px 24px;
+    letter-spacing: 0.01em;
+    display: inline-block;
+    text-transform: uppercase;
+    font-size: 14px;
+}
+@media (max-width: 640px) {
+    #onetrust-consent-sdk
+        div#onetrust-pc-sdk
+        .ot-pc-footer
+        .ot-btn-container
+        button.save-preference-btn-handler.onetrust-close-btn-handler {
+        margin: 20px 0 10px;
+        display: none;
+    }
+}
+#onetrust-consent-sdk
+    div#onetrust-pc-sdk
+    .ot-pc-footer
+    .ot-btn-container
+    button.save-preference-btn-handler.onetrust-close-btn-handler.visible {
+    visibility: visible !important;
+}
+@media (max-width: 640px) {
+    #onetrust-consent-sdk
+        div#onetrust-pc-sdk
+        .ot-pc-footer
+        .ot-btn-container
+        button.save-preference-btn-handler.onetrust-close-btn-handler.visible {
+        display: inline-block;
+    }
+}
+#onetrust-consent-sdk
+    div#onetrust-pc-sdk
+    .ot-pc-footer
+    .ot-btn-container
+    button#accept-recommended-btn-handler {
+    display: inline-block !important;
+    font-size: 14px;
+    font-weight: normal;
+    height: 48px;
+    padding: 14px 24px;
+    line-height: 1.1;
+    text-align: center;
+    min-width: 155px;
+    border-color: #0b5cab !important;
+    border-radius: 4px;
+    text-transform: uppercase;
+    margin: 0 15px;
+    background-color: #0b5cab !important;
+    color: #fff !important;
+}
+@media (max-width: 640px) {
+    #onetrust-consent-sdk
+        div#onetrust-pc-sdk
+        .ot-pc-footer
+        .ot-btn-container
+        button#accept-recommended-btn-handler {
+        margin: 5px 0 20px;
+    }
+}
+#onetrust-consent-sdk
+    div#onetrust-pc-sdk
+    .ot-pc-footer
+    .ot-btn-container
+    button#accept-recommended-btn-handler.optanon-ghost-button {
+    background-color: transparent !important;
+    color: #0b5cab !important;
+    font-size: 12.8px;
+    padding: 0 30px;
+}
+div#onetrust-banner-sdk {
+    max-width: none !important;
+    min-height: 194px;
+    top: 160px !important;
+    left: 0;
+    right: 0;
+    margin: 0 auto;
+    -webkit-box-shadow: 0 3px 7px rgba(0, 0, 0, 0.3);
+    -moz-box-shadow: 0 3px 7px rgba(0, 0, 0, 0.3);
+    box-shadow: 0 3px 7px rgba(0, 0, 0, 0.3);
+}
+@media (min-width: 897px) {
+    div#onetrust-banner-sdk {
+        width: 900px !important;
+    }
+}
+div#onetrust-banner-sdk .optanon-alert-box-bottom-top {
+    height: 0;
+}
+div#onetrust-banner-sdk #onetrust-policy {
+    margin-top: 0;
+}
+div#onetrust-banner-sdk .ot-sdk-container p {
+    color: #000 !important;
+    font-size: 11pt !important;
+    line-height: 16pt !important;
+    margin: 0 30px !important;
+    font-family: 'SalesforceSansRegular', Helvetica, Arial, sans-serif;
+    padding-bottom: 0;
+    padding-top: 30px;
+}
+@media (max-width: 768px) {
+    div#onetrust-banner-sdk .ot-sdk-container p {
+        color: #181818 !important;
+        font-size: 15px !important;
+        line-height: 24px !important;
+    }
+}
+div#onetrust-banner-sdk .ot-sdk-container p a {
+    text-decoration: none !important;
+    font-family: 'SalesforceSansBold', Helvetica, Arial, sans-serif;
+    color: #0b5cab;
+    cursor: pointer;
+}
+div#onetrust-banner-sdk .ot-sdk-container #onetrust-button-group-parent #onetrust-button-group,
+div#onetrust-banner-sdk .ot-sdk-container #onetrust-button-group-parent .banner-actions-container {
+    float: left;
+}
+div#onetrust-banner-sdk
+    .ot-sdk-container
+    #onetrust-button-group-parent
+    #onetrust-accept-btn-handler {
+    background-color: #0b5cab;
+    height: 47px;
+    border-radius: 4px;
+    padding: 14px 24px;
+    font-size: 14px;
+    border: 0;
+    width: auto;
+    line-height: 100%;
+    text-transform: uppercase;
+}
+div#onetrust-banner-sdk .has-reject-all-button #onetrust-pc-btn-handler {
+    display: inline-block !important;
+    font-size: 14px;
+    font-weight: normal;
+    min-height: 48px;
+    padding: 14px 24px;
+    line-height: 1.1;
+    text-align: center;
+    min-width: 155px;
+    border-radius: 4px;
+    text-transform: uppercase;
+    margin: 0 15px;
+    float: none;
+    max-width: 90%;
+}
+@media (min-width: 897px) {
+    div#onetrust-banner-sdk .has-reject-all-button #onetrust-pc-btn-handler {
+        float: right;
+    }
+}
+div#onetrust-banner-sdk .has-reject-all-button .banner-actions-container {
+    max-width: 100%;
+}
+@media (max-width: 896px) {
+    div#onetrust-banner-sdk .has-reject-all-button .banner-actions-container {
+        float: none !important;
+        text-align: center;
+    }
+}
+div#onetrust-banner-sdk .has-reject-all-button #onetrust-button-group #onetrust-reject-all-handler {
+    border: 0 !important;
+    height: 47px !important;
+    min-width: 155px !important;
+    border-radius: 4px !important;
+    margin: 0 15px 10px 0 !important;
+    background-color: #0b5cab !important;
+    color: #fff !important;
+    border-color: #0b5cab !important;
+    padding: 14px 24px !important;
+    letter-spacing: 0.01em !important;
+    display: inline-block !important;
+    text-transform: uppercase !important;
+    font-size: 14px !important;
+}
+@media (max-width: 640px) {
+    div#onetrust-banner-sdk
+        .has-reject-all-button
+        #onetrust-button-group
+        #onetrust-reject-all-handler,
+    div#onetrust-banner-sdk .has-reject-all-button #onetrust-button-group #onetrust-pc-btn-handler,
+    div#onetrust-banner-sdk
+        .has-reject-all-button
+        #onetrust-button-group
+        #onetrust-accept-btn-handler {
+        width: 100%;
+        margin-left: 0 !important;
+        margin-right: 0 !important;
+        max-width: 100%;
+    }
+    div#onetrust-banner-sdk
+        .has-reject-all-button
+        #onetrust-button-group
+        #onetrust-reject-all-handler {
+        margin-left: 0 !important;
+    }
+}

--- a/docs/src/client/assets/js/lwc/onetrust.js
+++ b/docs/src/client/assets/js/lwc/onetrust.js
@@ -1,0 +1,188 @@
+/*globals console */
+/* eslint-disable */
+var SfdcWwwBase = SfdcWwwBase || {};
+
+var oneTrustComponent = (function() {
+    'use strict';
+
+    // oneTrustContainer gets set in waitForOneTrustContainer()
+    var oneTrustContainer,
+        count = 0;
+    var Keyboard = {
+        TAB: 9,
+        ESCAPE: 27,
+        ENTER: 13,
+        SPACE: 32,
+        LEFT: 37,
+        RIGHT: 39,
+    };
+
+    function changeButtons() {
+        var categoryItems =
+            oneTrustContainer && oneTrustContainer.querySelectorAll('.category-menu-switch-handler')
+                ? oneTrustContainer.querySelectorAll('.category-menu-switch-handler')
+                : false;
+        var saveCookiesButton =
+            oneTrustContainer && oneTrustContainer.querySelector('.save-preference-btn-handler')
+                ? oneTrustContainer.querySelector('.save-preference-btn-handler')
+                : false;
+        var acceptCookiesButton =
+            oneTrustContainer && oneTrustContainer.querySelector('#accept-recommended-btn-handler')
+                ? oneTrustContainer.querySelector('#accept-recommended-btn-handler')
+                : false;
+        var generalContentArea =
+            oneTrustContainer && oneTrustContainer.querySelector('#ot-tab-desc')
+                ? oneTrustContainer.querySelector('#ot-tab-desc')
+                : false;
+
+        // Update backbutton in cookie list to move span inside of button
+        var listSection =
+            oneTrustContainer && oneTrustContainer.querySelector('#ot-pc-lst')
+                ? oneTrustContainer.querySelector('#ot-pc-lst')
+                : false;
+        var headingSection =
+            listSection && listSection.querySelector('#ot-lst-title')
+                ? listSection.querySelector('#ot-lst-title')
+                : false;
+        var backButton =
+            headingSection && headingSection.querySelector('.back-btn-handler')
+                ? headingSection.querySelector('.back-btn-handler')
+                : false;
+        var headingSecSpan =
+            headingSection && headingSection.getElementsByTagName('span')
+                ? headingSection.getElementsByTagName('span')
+                : false;
+
+        // Move span inside of button so all can be selected or clicked, not just tiny arrow
+        if (backButton && headingSecSpan) backButton.appendChild(headingSecSpan[0]);
+
+        // Setup button toggles to show/hide save all button
+        function toggleButtons(categoryItem) {
+            if (saveCookiesButton && acceptCookiesButton) {
+                if (typeof categoryItem.parentElement.dataset.optanongroupid === 'undefined') {
+                    if (saveCookiesButton.classList.contains('visible'))
+                        saveCookiesButton.classList.remove('visible');
+                    if (acceptCookiesButton.classList.contains('optanon-ghost-button'))
+                        acceptCookiesButton.classList.remove('optanon-ghost-button');
+                } else {
+                    saveCookiesButton.classList.add('visible');
+                    acceptCookiesButton.classList.add('optanon-ghost-button');
+                }
+            }
+        }
+
+        // Loop over links to add click and keydown events to call toggleButtons()
+        for (let i = 0; i < categoryItems.length; i++) {
+            // Click events
+            categoryItems[i].addEventListener('click', function(e) {
+                toggleButtons(e.currentTarget);
+            });
+
+            // Add keyboard navigation event to toggle buttons
+            categoryItems[i].addEventListener('keydown', function(e) {
+                // Arrow keys - left and right
+                if (e.keyCode === Keyboard.LEFT || e.keyCode === Keyboard.RIGHT)
+                    toggleArrowKeyDirection();
+            });
+        }
+
+        // OneTrust tool not fully accessible. Needs a little help with tab key and shift + tab keys
+        if (
+            generalContentArea &&
+            saveCookiesButton &&
+            acceptCookiesButton &&
+            categoryItems.length
+        ) {
+            for (let i = 0; i < categoryItems.length; i++) {
+                if (i === 0) {
+                    // Add listener to first item in list only.
+                    categoryItems[0].addEventListener('keydown', function(e) {
+                        if (e.shiftKey === true && e.keyCode === Keyboard.TAB) {
+                            // Look for shift + tab key
+                            // Time out needed to prevent collision with OneTrust listener on tab key
+                            setTimeout(function() {
+                                acceptCookiesButton.focus();
+                            }, 100);
+                        }
+                        if (e.shiftKey === false && e.keyCode === Keyboard.TAB) {
+                            // Look for tab key
+                            // Time out needed to prevent collision with OneTrust listener on tab key
+                            setTimeout(function() {
+                                generalContentArea.focus();
+                            }, 100);
+                        }
+                    });
+                } else {
+                    // Captures focus to only OneTrust tool. Prevents shift tab from going into page level elements
+                    categoryItems[i].addEventListener('keydown', function(e) {
+                        if (e.shiftKey === true && e.keyCode === Keyboard.TAB) {
+                            // Look for shift + tab key
+                            // Time out needed to prevent collision with OneTrust listener on tab key
+                            setTimeout(function() {
+                                acceptCookiesButton.focus();
+                            }, 100);
+                        }
+                    });
+                }
+            }
+        }
+
+        // OneTrust activates menu items with left and right arrow keys.
+        // We just need to look for the active item and pass it into toggleButtons()
+        function toggleArrowKeyDirection() {
+            // Check for active menu then pass it into toggle button function
+            for (let i = 0; i < categoryItems.length; i++) {
+                if (categoryItems[i].classList.contains('ot-active-menu')) {
+                    toggleButtons(categoryItems[i]);
+                }
+            }
+        }
+    }
+
+    function waitForOneTrustContainer() {
+        // Container may not be on the page at the time of page load, wait for it
+        var oneTrustStatusInterval = setInterval(function() {
+            // Try to set one trust container
+            oneTrustContainer = document.querySelector('#onetrust-pc-sdk');
+            // Check that we have a container
+            if (
+                oneTrustContainer !== undefined &&
+                oneTrustContainer !== null &&
+                oneTrustContainer
+            ) {
+                // If we have a container, proceed with change button wireup. Then clear interval.
+                changeButtons();
+                clearInterval(oneTrustStatusInterval);
+            }
+
+            if (count++ > 10) {
+                // timeout if this takes more than 5 sec
+                clearInterval(oneTrustStatusInterval);
+            }
+        }, 500);
+    }
+
+    function init() {
+        waitForOneTrustContainer();
+    }
+
+    return {
+        init: init,
+        oneTrustComponent: oneTrustComponent,
+    };
+})();
+
+function runOneTrustComponent() {
+    oneTrustComponent.init();
+}
+
+// In case the document is already rendered
+if (document.readyState != 'loading') runOneTrustComponent();
+// Modern browsers
+else if (document.addEventListener)
+    document.addEventListener('DOMContentLoaded', runOneTrustComponent);
+// IE <= 8
+else
+    document.attachEvent('onreadystatechange', function() {
+        if (document.readyState == 'complete') runOneTrustComponent();
+    });

--- a/docs/src/client/template.html
+++ b/docs/src/client/template.html
@@ -130,7 +130,7 @@
 		<div style="display:none">{{BOTTOM_RUNTIME_PLACEHOLDER}}</div>
 		
 		<!-- OneTrust Cookies Consent Notice start for bestjs.dev -->
-		<script src="https://a.sfdcstatic.com/enterprise/bestjs/uat/6140/oneTrust/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="869194d9-5b37-4d66-b7c1-dc6d705efb5f" ></script>
+		<script src="https://a.sfdcstatic.com/enterprise/bestjs/prod/6140/oneTrust/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="869194d9-5b37-4d66-b7c1-dc6d705efb5f" ></script>
 		<script src="/assets/js/onetrust.js" ></script>
 		<script type="text/javascript">
 		function OptanonWrapper() { }

--- a/docs/src/client/template.html
+++ b/docs/src/client/template.html
@@ -2,6 +2,15 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8">
+
+		<!-- OneTrust Cookies Consent Notice start for bestjs.dev -->
+		<script src="https://a.sfdcstatic.com/enterprise/bestjs/prod/6140/oneTrust/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="869194d9-5b37-4d66-b7c1-dc6d705efb5f" ></script>
+		<script src="/assets/js/onetrust.js" ></script>
+		<script type="text/javascript">
+		function OptanonWrapper() { }
+		</script>
+		<!-- OneTrust Cookies Consent Notice end for bestjs.dev -->
+
         <script async src="https://www.googletagmanager.com/gtag/js?id=UA-145121138-1"></script>
         <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('config', 'UA-145121138-1');</script>
 
@@ -22,6 +31,7 @@
 		<link rel="icon" href="/assets/images/logo.svg">
 
 		<title>{{TITLE}}</title>
+		<link rel="stylesheet" href="/assets/css/cookie-consent.css" />
 		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
 		{{HEADER_STYLES}}
 		{{HEADER_SCRIPTS}}
@@ -111,6 +121,7 @@
 						<li><a href="https://opensource.salesforce.com/" target="_blank" rel="noopener">Open Source</a></li>
 						<li><a href="https://engineering.salesforce.com/" target="_blank" rel="noopener">Engineering</a></li>
 						<li><a href="http://salesforce.com/dreamjob" target="_blank" rel="noopener">Careers</a></li>
+						<li><a href="#" class="optanon-toggle-display" data-ignore-geolocation="true">Cookie Preferences</a></li>
 					</ul>
 				</div>
 				<div class="social-links links">

--- a/docs/src/client/template.html
+++ b/docs/src/client/template.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8">
 
 		<!-- OneTrust Cookies Consent Notice start for bestjs.dev -->
-		<script src="https://a.sfdcstatic.com/enterprise/bestjs/prod/6140/oneTrust/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="869194d9-5b37-4d66-b7c1-dc6d705efb5f" ></script>
+		<script src="https://a.sfdcstatic.com/enterprise/bestjs/uat/6140/oneTrust/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="869194d9-5b37-4d66-b7c1-dc6d705efb5f" ></script>
 		<script src="/assets/js/onetrust.js" ></script>
 		<script type="text/javascript">
 		function OptanonWrapper() { }

--- a/docs/src/client/template.html
+++ b/docs/src/client/template.html
@@ -3,14 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 
-		<!-- OneTrust Cookies Consent Notice start for bestjs.dev -->
-		<script src="https://a.sfdcstatic.com/enterprise/bestjs/uat/6140/oneTrust/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="869194d9-5b37-4d66-b7c1-dc6d705efb5f" ></script>
-		<script src="/assets/js/onetrust.js" ></script>
-		<script type="text/javascript">
-		function OptanonWrapper() { }
-		</script>
-		<!-- OneTrust Cookies Consent Notice end for bestjs.dev -->
-
         <script async src="https://www.googletagmanager.com/gtag/js?id=UA-145121138-1"></script>
         <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('config', 'UA-145121138-1');</script>
 
@@ -136,6 +128,15 @@
 		</footer>
 
 		<div style="display:none">{{BOTTOM_RUNTIME_PLACEHOLDER}}</div>
+		
+		<!-- OneTrust Cookies Consent Notice start for bestjs.dev -->
+		<script src="https://a.sfdcstatic.com/enterprise/bestjs/uat/6140/oneTrust/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="869194d9-5b37-4d66-b7c1-dc6d705efb5f" ></script>
+		<script src="/assets/js/onetrust.js" ></script>
+		<script type="text/javascript">
+		function OptanonWrapper() { }
+		</script>
+		<!-- OneTrust Cookies Consent Notice end for bestjs.dev -->
+
 		<script src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
 		<script>docsearch({apiKey:'ffea0219f83348ba14077d8ac71f76b7',indexName:'bestjs',inputSelector:'.search-input'})</script>
 	</body>

--- a/packages/@best/runner-abstract/src/__tests__/abstractRunner.spec.ts
+++ b/packages/@best/runner-abstract/src/__tests__/abstractRunner.spec.ts
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
 import { existsSync } from 'fs';
 import express from 'express';
 import {


### PR DESCRIPTION
## Details

**THIS PR IS CURRENTLY A WIP FOR ONLINE TESTING IN STAGING. UPON COMPLETION OF TESTING I'LL REQUEST REVIEW**

This PR will add branded cookie consent banners to the site for end users to accept/reject/modify cookie utilization on lwc.dev. In order to test this change's functionality make sure to use a VPN and use EMEA-1 in order to see the banner. In other VPN locales the only functional difference will be a cookie visible in the dev tools or if you click the "Cookie Preferences" link in the footer of the site.

The current PR has the following file being served from sfdstatic.com: `https://a.sfdcstatic.com/enterprise/bestjs/uat/6140/oneTrust/scripttemplates/otSDKStub.js`. This script is setup on the server as the test script and will work on heroku for testing.

Upon general approval and final test with any changes I will update that script to the following: `https://a.sfdcstatic.com/enterprise/bestjs/prod/6140/oneTrust/scripttemplates/otSDKStub.js` which is setup on the server to work with bestjs.dev.

## Does this PR introduce a breaking change?
No