### PR TITLE
chore: combine duplicate req implementations

### DIFF
--- a/packages/@best/api-db/src/utils.ts
+++ b/packages/@best/api-db/src/utils.ts
@@ -7,15 +7,10 @@
 
 import path from 'path';
 import { FrozenGlobalConfig, FrontendConfig } from '@best/types';
+import { req } from '@best/utils';
 import { ApiDBAdapter } from './types';
 
 const LOCAL_ADAPTERS = ['sql/postgres', 'sql/sqlite'];
-
-// Handles default exports for both ES5 and ES6 syntax
-function req(id: string) {
-    const r = require(id);
-    return r.default || r;
-}
 
 export const loadDbFromConfig = (globalConfig: FrozenGlobalConfig | FrontendConfig): ApiDBAdapter => {
     const config = globalConfig.apiDatabase;

--- a/packages/@best/builder/src/build-benchmark.ts
+++ b/packages/@best/builder/src/build-benchmark.ts
@@ -13,18 +13,13 @@ import mkdirp from "mkdirp";
 import benchmarkRollup from './rollup-plugin-benchmark-import';
 import generateHtml from './html-templating';
 import { FrozenGlobalConfig, FrozenProjectConfig, ProjectConfigPlugin, BuildConfig } from '@best/types';
+import { req } from '@best/utils';
 
 const BASE_ROLLUP_OUTPUT: OutputOptions = { format: 'iife' };
 const ROLLUP_CACHE = new Map();
 
 function md5(data: string) {
     return crypto.createHash('md5').update(data).digest('hex');
-}
-
-// Handles default exports for both ES5 and ES6 syntax
-function req(id: string) {
-    const r = require(id);
-    return r.default || r;
 }
 
 function addResolverPlugins(plugins: ProjectConfigPlugin[]): any[] {

--- a/packages/@best/utils/src/__tests__/req.spec.ts
+++ b/packages/@best/utils/src/__tests__/req.spec.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+*/
+
+import path from 'path';
+import { req } from '../req';
+
+describe('req', () => {
+    it('returns the default export for an es5 module', () => {
+        expect(req(path.join(__dirname, 'req', 'mockEs5Module.js'))).toBe('this is the default es5 export');
+    });
+
+    it('returns the default export for an es6 module', () => {
+        expect(req(path.join(__dirname, 'req', 'mockEs6Module.js'))).toBe('this is the default es6 export');
+    });
+});

--- a/packages/@best/utils/src/__tests__/req/mockEs5Module.js
+++ b/packages/@best/utils/src/__tests__/req/mockEs5Module.js
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+*/
+
+module.exports = 'this is the default es5 export';

--- a/packages/@best/utils/src/__tests__/req/mockEs6Module.js
+++ b/packages/@best/utils/src/__tests__/req/mockEs6Module.js
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+*/
+
+const es6default = 'this is the default es6 export';
+export default es6default;

--- a/packages/@best/utils/src/index.ts
+++ b/packages/@best/utils/src/index.ts
@@ -12,5 +12,6 @@ export { getSystemInfo } from './system-info';
 export { default as logError } from './log-error';
 export { proxifiedSocketOptions } from './proxy';
 export { matchSpecs } from './match-specs';
+export { req } from './req';
 export { RunnerInterruption } from './runner-interruption';
 export { normalizeClientConfig, normalizeSpecs } from './normalize-client-config';

--- a/packages/@best/utils/src/req.ts
+++ b/packages/@best/utils/src/req.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+*/
+
+/**
+ * Handles default exports for both ES5 and ES6 syntax
+ */
+export function req(id: string) {
+    const r = require(id);
+    return r.default || r;
+}


### PR DESCRIPTION
## Details
Combines duplicate `req` implementations (putting the combined one in `@best/utils`) and adds test covering the method.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No