### PR TITLE
chore(deps): bump systeminformation to 5.7.7

### DIFF
--- a/packages/@best/types/src/config.ts
+++ b/packages/@best/types/src/config.ts
@@ -228,7 +228,7 @@ export interface EnvironmentConfig {
             brand: string;
             family: string;
             model: string;
-            speed: string;
+            speed: number;
             cores: number;
         },
         os: { platform: string, distro: string, release: string, kernel: string, arch: string };

--- a/packages/@best/utils/package.json
+++ b/packages/@best/utils/package.json
@@ -14,10 +14,7 @@
     "chalk": "~2.4.2",
     "https-proxy-agent": "^5.0.0",
     "is-ci": "~2.0.0",
-    "systeminformation": "~4.27.11"
-  },
-  "devDependencies": {
-    "@types/systeminformation": "^3.23.1"
+    "systeminformation": "~5.7.7"
   },
   "files": [
     "build/**/*.js"

--- a/packages/@best/utils/src/__tests__/system-info.spec.ts
+++ b/packages/@best/utils/src/__tests__/system-info.spec.ts
@@ -20,7 +20,7 @@ test('getSystemInfo', async () => {
                 brand: expect.any(String),
                 family: expect.any(String),
                 model: expect.any(String),
-                speed: expect.any(String),
+                speed: expect.any(Number),
                 cores: expect.any(Number),
             },
             os: {

--- a/packages/@best/utils/src/system-info.ts
+++ b/packages/@best/utils/src/system-info.ts
@@ -11,7 +11,7 @@ export async function getSystemInfo() {
     const system = await si.system();
     const cpu = await si.cpu();
     const { platform, distro, release, kernel, arch } = await si.osInfo();
-    const { avgload } = await si.currentLoad();
+    const { avgLoad } = await si.currentLoad();
 
     return {
         system: {
@@ -27,6 +27,6 @@ export async function getSystemInfo() {
             cores: cpu.cores,
         },
         os: { platform, distro, release, kernel, arch },
-        load: { cpuLoad: avgload },
+        load: { cpuLoad: avgLoad },
     };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3458,13 +3458,6 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
-"@types/systeminformation@^3.23.1":
-  version "3.54.1"
-  resolved "https://registry.yarnpkg.com/@types/systeminformation/-/systeminformation-3.54.1.tgz#bbc1b9e4ae2e60d45f75906029c6fb5436e1c5cb"
-  integrity sha512-vvisj2mdWygyc0jk/5XtSVq9gtxCmF3nrGwv8wVway8pwNRhtPji/MU9dc1L0F6rl0F/NFIHa4ScRU7wmNaHmg==
-  dependencies:
-    systeminformation "*"
-
 "@types/tar@^4.0.0":
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/@types/tar/-/tar-4.0.3.tgz#e2cce0b8ff4f285293243f5971bd7199176ac489"
@@ -16971,10 +16964,10 @@ synchronous-promise@^2.0.6:
   resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-2.0.9.tgz#b83db98e9e7ae826bf9c8261fd8ac859126c780a"
   integrity sha512-LO95GIW16x69LuND1nuuwM4pjgFGupg7pZ/4lU86AmchPKrhk0o2tpMU2unXRrqo81iAFe1YJ0nAGEVwsrZAgg==
 
-systeminformation@*, systeminformation@~4.27.11:
-  version "4.27.11"
-  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-4.27.11.tgz#6dbe96e48091444f80dab6c05ee1901286826b60"
-  integrity sha512-U7bigXbOnsB8k1vNHS0Y13RCsRz5/UohiUmND+3mMUL6vfzrpbe/h4ZqewowB+B+tJNnmGFDj08Z8xGfYo45dQ==
+systeminformation@~5.7.7:
+  version "5.7.7"
+  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-5.7.7.tgz#f39d2ec4c72820aa97efd6f32021e455f20d1e61"
+  integrity sha512-aQ7MBeVI2MKPYOi3YJAoZ45JVlRkBA7IXoqGgtVBamvtE0I6JLOyJzD/VVc9pnMXDb3yqaMwssAjhwtJax4/Rw==
 
 table@^5.2.3:
   version "5.4.0"


### PR DESCRIPTION
## Details
Updates `systeminformation` dependency to 5.7.7.

Requires manual changes on our end because 5.x introduced API changes in `systeminformation` supersedes #271.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No
