### PR TITLE
chore: replace `cli-table` with `cli-table3`

### DIFF
--- a/packages/@best/cli/package.json
+++ b/packages/@best/cli/package.json
@@ -28,7 +28,7 @@
     "@best/utils": "5.0.1",
     "asciichart": "1.5.7",
     "chalk": "~2.4.2",
-    "cli-table": "0.3.11",
+    "cli-table3": "0.6.1",
     "fast-glob": "~3.0.0",
     "micromatch": "~3.1.10",
     "rimraf": "~2.6.2",

--- a/packages/@best/cli/src/cli/output.ts
+++ b/packages/@best/cli/src/cli/output.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
 */
 
-import Table from 'cli-table';
+import Table from 'cli-table3';
 import chalk from 'chalk';
 import Histogram from './histogram';
 
@@ -160,7 +160,9 @@ export default class Output {
     compare(result: BenchmarkComparison) {
         const { baseCommit, targetCommit } = result;
 
-        type GroupedTables = { [projectName: string]: Table[] }
+        type GroupedTables = {
+            [projectName: string]: Table[]
+        }
 
         const tables: GroupedTables = result.comparisons.reduce((tables, node): GroupedTables => {
             if (node.type === "project" || node.type === "group") {

--- a/packages/@best/cli/typings/cli-table3.d.ts
+++ b/packages/@best/cli/typings/cli-table3.d.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
 */
 
-declare module 'cli-table' {
+declare module 'cli-table3' {
     export default class Table {
         constructor(obj: any)
         push(rows: string[]): void

--- a/yarn.lock
+++ b/yarn.lock
@@ -5784,12 +5784,14 @@ cli-spinners@^2.1.0:
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.2.0.tgz#e8b988d9206c692302d8ee834e7a85c0144d8f77"
   integrity sha512-tgU3fKwzYjiLEQgPMD9Jt+JjHVL9kW93FiIMX/l7rivvOD4/LL0Mf7gda3+4U2KJBloybwgj5KEoQgGRioMiKQ==
 
-cli-table@0.3.11:
-  version "0.3.11"
-  resolved "https://registry.yarnpkg.com/cli-table/-/cli-table-0.3.11.tgz#ac69cdecbe81dccdba4889b9a18b7da312a9d3ee"
-  integrity sha512-IqLQi4lO0nIB4tcdTpN4LCB9FI3uqrJZK7RC515EnhZ6qBaglkIgICb1wjeAqpdoOabm1+SuQtkXIPdYC93jhQ==
+cli-table3@0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.1.tgz#36ce9b7af4847f288d3cdd081fbd09bf7bd237b8"
+  integrity sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==
   dependencies:
-    colors "1.0.3"
+    string-width "^4.2.0"
+  optionalDependencies:
+    colors "1.4.0"
 
 cli-truncate@^0.2.1:
   version "0.2.1"
@@ -5995,10 +5997,10 @@ colors@*, colors@^1.2.1:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.3.tgz#39e005d546afe01e01f9c4ca8fa50f686a01205d"
   integrity sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==
 
-colors@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
-  integrity sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
+colors@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
 colors@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
From https://github.com/cli-table/cli-table3/tree/90c7438c94e4a14c71c5f16c9e4209b4435e5b37#cli-table3:

> `cli-table3` is based on (and api compatible with) the original `cli-table`, and `cli-table2`, which are both unmaintained. `cli-table3` includes all the additional features from cli-table2.