### PR TITLE
fix: store temporary files in unique folder to avoid race conditions

### DIFF
--- a/packages/@best/utils/src/__tests__/random.spec.ts
+++ b/packages/@best/utils/src/__tests__/random.spec.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+*/
+
+import { randomAlphanumeric } from '../random';
+
+describe('randomAlphanumeric', () => {
+    test('returns random string whose length matches requested length', () => {
+        for (let len = 0; len < 100; len ++) {
+            const str = randomAlphanumeric(len);
+            expect(str).toHaveLength(len);
+        }
+    });
+
+    test('returns empty string when length requested is less than 1', () => {
+        const str = randomAlphanumeric(0);
+        expect(str).toBe('');
+
+    });
+
+    test('returns empty string when length parameter is negative number', () => {
+        const str = randomAlphanumeric(-15);
+        expect(str).toBe('');
+    });
+});

--- a/packages/@best/utils/src/index.ts
+++ b/packages/@best/utils/src/index.ts
@@ -14,3 +14,4 @@ export { proxifiedSocketOptions } from './proxy';
 export { matchSpecs } from './match-specs';
 export { RunnerInterruption } from './runner-interruption';
 export { normalizeClientConfig, normalizeSpecs } from './normalize-client-config';
+export { randomAlphanumeric } from './random';

--- a/packages/@best/utils/src/random.ts
+++ b/packages/@best/utils/src/random.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+*/
+
+const ALPHANUMERIC_CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+const ALPHANUMERIC_CHARACTERS_LENGTH = ALPHANUMERIC_CHARACTERS.length;
+
+/**
+ * Creates a random alphanumeric string whose length is the number of characters specified.
+ * @param length The length of the random string to create
+ * @returns The random string
+ */
+export const randomAlphanumeric = (length: Number): string => {
+    if (length < 1) {
+        return "";
+    }
+
+    let randomString = "";
+
+    for (let i = 0; i < length; i++) {
+        // Note: Math.random returns a decimal value between 0 (inclusive) and 1 (exclusive).
+        // Since it will never return a 1 and we are doing Math.floor here, the index will never
+        // be larger than (ALPHANUMERIC_CHARACTERS_LENGTH-1)
+        const index = Math.floor(Math.random() * ALPHANUMERIC_CHARACTERS_LENGTH);
+        randomString += ALPHANUMERIC_CHARACTERS[index];
+    }
+
+    return randomString;
+}


### PR DESCRIPTION
## Details
This PR resolves a race condition where concurrent benchmarks that happen to have the same benchmark name end up corrupting the temporary files because they are overwriting each other. By storing the temporary files in unique directories, this race condition cannot happen. 

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No