### PR TITLE
feat: add support for http proxy in REST DB Adapter

### DIFF
--- a/packages/@best/api-db/package.json
+++ b/packages/@best/api-db/package.json
@@ -7,12 +7,11 @@
     },
     "version": "6.0.1",
     "dependencies": {
-        "node-fetch": "~2.6.1",
+        "https-proxy-agent": "^5.0.0",
         "pg": "^8.4.1",
         "sqlite": "^3.0.3"
     },
     "devDependencies": {
-        "@types/node-fetch": "2.5.12",
         "@types/pg": "^7.4.14"
     },
     "main": "build/index.js",


### PR DESCRIPTION
## Details
The previously-used `node-fetch` library does not support proxies.
With this change, the results can be pushed to the frontend over an HTTP proxy.

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No