### PR TITLE
fix: make front-end show by default the results for the last 2 months

### DIFF
--- a/packages/@best/frontend/server/static/index.ts
+++ b/packages/@best/frontend/server/static/index.ts
@@ -28,7 +28,7 @@ export const buildStaticFrontend = async (results: BenchmarkResultsSnapshot[], g
 
     const options = {
         projectNames,
-        timingOptions: ['all', '2-months', 'last-release'],
+        timingOptions: ['2-months', 'last-release', 'all'],
         config: { apiDatabase: globalConfig.apiDatabase }
     }
 

--- a/packages/@best/frontend/src/modules/component/benchmark/benchmark.js
+++ b/packages/@best/frontend/src/modules/component/benchmark/benchmark.js
@@ -43,7 +43,7 @@ export default class ComponentBenchmark extends LightningElement {
 
         if (this.element) {
             relayout(this.element, this.currentLayout);
-            
+
             // eslint-disable-next-line lwc/no-raf, @lwc/lwc/no-async-operation
             window.requestAnimationFrame(() => {
                 this.updateGraphZoom();
@@ -141,7 +141,7 @@ export default class ComponentBenchmark extends LightningElement {
 
     rawClickHandler(event) {
         const grandParent = event.target.parentElement.parentElement;
-        
+
         if (grandParent !== this.element && this.recentHoverData) {
             this.traceClicked();
         }
@@ -199,7 +199,7 @@ export default class ComponentBenchmark extends LightningElement {
                     this.selectedPoints[idx] = { ...pastPoint, pendingCompare: false };
                     return false;
                 }
-    
+
                 return true;
             })
         } else {
@@ -210,7 +210,7 @@ export default class ComponentBenchmark extends LightningElement {
                     this.selectedPoints[idx] = { ...pastPoint, hidden: true, pendingCompare: true };
                     return false;
                 }
-    
+
                 return true;
             })
         }

--- a/packages/@best/frontend/src/modules/component/menubar/menubar.js
+++ b/packages/@best/frontend/src/modules/component/menubar/menubar.js
@@ -29,11 +29,11 @@ export default class ComponentMenubar extends LightningElement {
     get timingOptions() {
         const items = [
             {
-                title: 'Since Last Release',
-                id: 'last-release'
-            }, {
                 title: 'Past 2 Months',
                 id: '2-months'
+            }, {
+                title: 'Since Last Release',
+                id: 'last-release'
             }, {
                 title: 'All Time',
                 id: 'all'

--- a/packages/@best/frontend/src/modules/store/api/api.js
+++ b/packages/@best/frontend/src/modules/store/api/api.js
@@ -28,7 +28,7 @@ export async function fetchSnapshots(project, timing) {
     const timeParams = timeQuery(project, timing);
     const response = await fetch(createURL(`${project.id}/snapshots?${timeParams}`));
     const { snapshots } = await response.json();
-    return snapshots || []; 
+    return snapshots || [];
 }
 
 export async function fetchCommitInfo(commit) {

--- a/packages/@best/frontend/src/modules/store/store/reducers.js
+++ b/packages/@best/frontend/src/modules/store/store/reducers.js
@@ -60,7 +60,7 @@ export function benchmarks(
 
 export function view(
     state = {
-        timing: 'last-release',
+        timing: '2-months',
         benchmark: 'all',
         metric: 'all',
         zoom: {}, // this goes directly to/from plotly,

--- a/packages/@best/frontend/src/modules/view/benchmarks/benchmarks.js
+++ b/packages/@best/frontend/src/modules/view/benchmarks/benchmarks.js
@@ -68,7 +68,7 @@ export default class ViewBenchmarks extends LightningElement {
         if (! bench) {
             return '';
         }
-        
+
         let date;
         if (zoom) {
             const beginIndex = Math.ceil(zoom[0]);
@@ -86,7 +86,7 @@ export default class ViewBenchmarks extends LightningElement {
         if (! bench) {
             return '';
         }
-        
+
         let date;
         if (zoom) {
             const endIndex = Math.floor(zoom[1]);


### PR DESCRIPTION
## Details

Users seem to find it more useful to see by default the results for the last 2 months instead of the last release.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No