### PR TITLE
fix: set the correct state for the agent when a client disconnects

### DIFF
--- a/packages/@best/agent/src/agent.ts
+++ b/packages/@best/agent/src/agent.ts
@@ -174,6 +174,13 @@ export class Agent extends EventEmitter {
                     this.interruption.requestInterruption();
                 }
             }
+
+            /*
+             * Once the disconnect happens, the agent is now able to
+             * take on new tasks, hence, mark its state as "idle".
+             */
+
+            this.state = AgentState.IDLE;
         });
 
         // Forward events from the Client to the Agent


### PR DESCRIPTION
## Details

Before this change, when a client disconnected, the state of the agent would remain busy even though the agent would be idle, making everything hang indefinitely.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No