### PR TITLE
feat: add rest APIs for agent info to the hub

### DIFF
--- a/packages/@best/agent-hub/src/cli/index.ts
+++ b/packages/@best/agent-hub/src/cli/index.ts
@@ -17,10 +17,20 @@ export function run() {
     const hubConfig = getHubConfig();
 
     const app = express();
-    serveFrontend(app);
     const server = http.createServer(app);
-    const agent = new Hub(server, hubConfig);
-    observeAgent(server, agent);
+    const hub = new Hub(server, hubConfig);
+
+    app.get("/api/agents/:agentId", (req, res) => {
+        const { agentId } = req.params;
+        res.json(hub.getAgent(agentId));
+    });
+
+    app.get("/api/agents", (req, res) => {
+        res.json(hub.getAgents());
+    });
+
+    serveFrontend(app);
+    observeAgent(server, hub);
 
     server.listen(PORT);
     process.stdout.write(`Best Hub listening in port ${PORT}...\n`);

--- a/packages/@best/agent-hub/src/hub.ts
+++ b/packages/@best/agent-hub/src/hub.ts
@@ -244,4 +244,33 @@ export class Hub extends EventEmitter {
             activeClients
         };
     }
+
+    /**
+     * Gets a list of all agents connected to the hub
+     * @returns an array with connected agents
+     */
+    getAgents() {
+        return Array.from(this.connectedAgents).map(agent => agent.getState());
+    }
+
+    /**
+     * Gets agent info based on specified identifier.
+     * @param id a unique identifier of an agent
+     * @returns agent info
+     */
+    getAgent(id: string) {
+        const agents = Array.from(this.connectedAgents)
+                            .filter((agent) => agent.getId() === id)
+                            .map(agent => agent.getState());
+
+        if (!agents || agents.length === 0) {
+            return;
+        }
+
+        if (agents.length > 1) {
+            throw new Error(`Multiple agents with the same ID found. ID: ${id}`);
+        }
+
+        return agents[0];
+    }
 }


### PR DESCRIPTION
## Details
Currently, the Hub exposes agent info via a WebSocket transport and renders it as HTML in the browser. While it works great for this scenario, it is less desirable for external callers where they are mostly interested in point-in-time state of agents. For example, in order to integrate Best with auto-scaling functionality in AWS (or other cloud providers), simple stateless REST endpoints provide an easier integration option, therefore I opened this PR.

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [X] No