### PR TITLE
feat: add support for hub with self-signed certs

### DIFF
--- a/packages/@best/agent/src/cli/config.ts
+++ b/packages/@best/agent/src/cli/config.ts
@@ -5,6 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { AgentConfig, RemoteHubConfig } from '@best/types';
+import { coalesce } from '@best/utils';
 
 const AGENT_CONFIG = process.env.AGENT_CONFIG ? JSON.parse(process.env.AGENT_CONFIG): {};
 const AGENT_URI = process.env.AGENT_URI;
@@ -14,6 +15,7 @@ const AGENT_AUTH_TOKEN = process.env.AGENT_AUTH_TOKEN;
 const REMOTE_HUB_CONFIG = process.env.REMOTE_HUB_CONFIG ? JSON.parse(process.env.REMOTE_HUB_CONFIG): {};
 const REMOTE_HUB_URI = process.env.REMOTE_HUB_URI;
 const REMOTE_HUB_AUTH_TOKEN = process.env.REMOTE_HUB_AUTH_TOKEN;
+const REMOTE_HUB_ACCEPT_SELFSIGNED_CERT = process.env.REMOTE_HUB_ACCEPT_SELFSIGNED_CERT;
 
 function normalizeArgOptions(argv: string[]): any {
     let arg;
@@ -43,10 +45,46 @@ export function getAgentConfig(): AgentConfig {
     };
 }
 
+/**
+ * Tries to convert provided value to a boolean for a set of known/supported strings.
+ * @param val the value to be converted to boolean
+ * @returns `true` for 'true', 'yes' or '1'.
+ *          `false` for 'false', 'no', '0'.
+ *          `null` when value is null.
+ *          `undefined` when value is undefined or does not match one of supported values.
+ */
+function tryConvertToBoolean(val: string | undefined | null): boolean | undefined | null {
+    // Preserve the input's value if it is either null or undefined
+    if (val === null || val === undefined) {
+        return val;
+    }
+
+    // Convert to boolean for known/supported values
+    switch (val.toLowerCase().trim()) {
+        case 'true':
+        case 'yes':
+        case '1':
+            return true;
+        case 'false':
+        case 'no':
+        case '0':
+            return false;
+    }
+}
+
 export function getRemoteHubConfig(): RemoteHubConfig {
     return {
         ...REMOTE_HUB_CONFIG,
         uri: argv.remoteHubUri || REMOTE_HUB_URI || REMOTE_HUB_CONFIG.uri,
-        authToken: argv.remoteHubAuthToken || REMOTE_HUB_AUTH_TOKEN || REMOTE_HUB_CONFIG.authToken
+        authToken: argv.remoteHubAuthToken || REMOTE_HUB_AUTH_TOKEN || REMOTE_HUB_CONFIG.authToken,
+
+        // Since this config parameter is of a boolean type, we don't want to assume that the absence of
+        // the individual input's value is automatically considered as boolean false - we want to
+        // preserve the null or undefined value.
+        acceptSelfSignedCert: coalesce(
+            tryConvertToBoolean(argv.acceptSelfSignedCert),
+            tryConvertToBoolean(REMOTE_HUB_ACCEPT_SELFSIGNED_CERT),
+            tryConvertToBoolean(REMOTE_HUB_CONFIG.acceptSelfSignedCert)
+        )
     };
 }

--- a/packages/@best/agent/src/remote-hub.ts
+++ b/packages/@best/agent/src/remote-hub.ts
@@ -40,6 +40,14 @@ export default class RemoteHub extends EventEmitter {
             socketOptions.query.authToken = remoteHubConfig.authToken;
         }
 
+        if (remoteHubConfig.acceptSelfSignedCert != null) {
+            // When the hub is using a self-signed cert to enable HTTPS,
+            // SocketIO by default would reject connections to such endpoints.
+            // To allow connections to the hub with a self-signed cert, the
+            // `rejectUnauthorized` property has to false.
+            socketOptions.rejectUnauthorized = !remoteHubConfig.acceptSelfSignedCert;
+        }
+
         this.hubUri = uri;
 
         this.hubSocket = socketIOClient(uri, socketOptions);

--- a/packages/@best/types/src/config.ts
+++ b/packages/@best/types/src/config.ts
@@ -42,6 +42,7 @@ export interface RemoteHubConfig {
     uri: string;
     authToken: string;
     pingTimeout: number;
+    acceptSelfSignedCert: boolean;
 }
 
 export interface HubConfig {

--- a/packages/@best/utils/src/__tests__/coalesce.spec.ts
+++ b/packages/@best/utils/src/__tests__/coalesce.spec.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+*/
+
+import { coalesce } from '../coalesce';
+
+describe('coalesce', () => {
+    test('returns null when values are null or undefined', () => {
+        const noValues = coalesce();
+        expect(noValues).toBeUndefined();
+
+        const nullValues = coalesce(null, null, null);
+        expect(nullValues).toBeUndefined();
+
+        const undefinedValues = coalesce(undefined, undefined, undefined);
+        expect(undefinedValues).toBeUndefined();
+
+        const mixedValues = coalesce(undefined, null, undefined);
+        expect(mixedValues).toBeUndefined();
+    });
+
+    test('returns first value that is not null or undefined', () => {
+        const numericValue = coalesce(null, undefined, null, 123, undefined, 234, null);
+        expect(numericValue).toBe(123);
+
+        const booleanFalseValue = coalesce(null, undefined, null, false, undefined, true, null);
+        expect(booleanFalseValue).toBe(false);
+
+        const booleanTrueValue = coalesce(null, undefined, null, true, undefined, false, null);
+        expect(booleanTrueValue).toBe(true);
+
+        const obj = { x: 'abc' }
+        const objectValue = coalesce(null, undefined, obj);
+        expect(objectValue).toEqual(obj);
+    });
+});

--- a/packages/@best/utils/src/coalesce.ts
+++ b/packages/@best/utils/src/coalesce.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+*/
+
+/**
+ * Returns the first value that is not null or undefined
+ * @param values list of values to be searched
+ * @returns first non-null/non-undefined value, otherwise returns undefined
+ */
+export const coalesce = (...values: any): any => {
+    if (values === null || values === undefined) {
+        return null;
+    }
+
+    for (const val of values) {
+        if (val !== null && val !== undefined) {
+            return val;
+        }
+    }
+}

--- a/packages/@best/utils/src/index.ts
+++ b/packages/@best/utils/src/index.ts
@@ -15,3 +15,4 @@ export { matchSpecs } from './match-specs';
 export { RunnerInterruption } from './runner-interruption';
 export { normalizeClientConfig, normalizeSpecs } from './normalize-client-config';
 export { randomAlphanumeric } from './random';
+export { coalesce } from './coalesce';


### PR DESCRIPTION
## Details
In environments where a self-signed certificate is used for the hub (either behind a load balancer or a reverse proxy like nginx), the agents are unable to connect due to the default behavior of socket.io where it would reject connections to endpoints with self-signed certificate.

With this PR, agents can be configured to connect to a hub that is using a self-signed certificate.

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [X] No
